### PR TITLE
Fix MCP server transport type format in server-card.json

### DIFF
--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -4,7 +4,7 @@
   "description": "Deterministic refund eligibility notary for US consumer subscriptions. Stateless.",
   "transports": [
     {
-      "type": "streamable_http",
+      "type": "streamable-http",
       "url": "https://refund.decide.fyi/api/mcp"
     }
   ],


### PR DESCRIPTION
## Summary
Updated the MCP server transport type identifier to use the correct hyphenated format.

## Changes
- Changed transport type from `streamable_http` to `streamable-http` in the server card configuration
  - This aligns with the standardized naming convention for MCP transport types
  - Ensures compatibility with MCP clients that expect the hyphenated format

## Details
The server card configuration for the refund eligibility notary service was using an underscore-separated transport type identifier. This has been corrected to use the standard hyphenated format (`streamable-http`) to match MCP specification conventions and ensure proper client recognition and handling of the transport type.