### PR TITLE
Add logging for incoming MCP requests

### DIFF
--- a/api/mcp.js
+++ b/api/mcp.js
@@ -127,6 +127,13 @@ export default async function handler(req, res) {
 
     const { id = null, method, params } = msg || {};
 
+    // Log all incoming MCP requests
+    console.error('[MCP Request]', JSON.stringify({
+      method,
+      timestamp: new Date().toISOString(),
+      ip: clientIp
+    }));
+
     if (!method) return send(res, 200, err(id, -32600, "Invalid Request", { message: "method field is required" }));
 
     // initialize


### PR DESCRIPTION
## Summary
Added request logging to the MCP API handler to track incoming requests for debugging and monitoring purposes.

## Changes
- Added console logging for all incoming MCP requests that captures:
  - The RPC method being called
  - Timestamp of the request in ISO format
  - Client IP address making the request

## Implementation Details
- Logging is placed immediately after extracting the request payload to capture all requests before validation
- Uses `console.error()` to ensure logs are written to stderr (standard practice for application logs)
- Logs are output in JSON format for easier parsing and analysis
- This will help with debugging, monitoring request patterns, and identifying potential issues with specific clients