### PR TITLE
Add edge middleware passthrough to avoid Next import

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,3 @@
+export default async function middleware(request) {
+  return fetch(request);
+}


### PR DESCRIPTION
### Motivation
- Add a minimal edge middleware to proxy requests to origin so the project does not need to import `next/server`, which can be unsupported in some edge runtimes.

### Description
- Create `middleware.js` that exports a default async `middleware(request)` which simply returns `fetch(request)` to act as a passthrough for edge deployments.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a98a75c48321b256aab2f2c2049a)