### PR TITLE
Update README, docs, and version to 1.2.0 for all 4 MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,358 +1,270 @@
-# refund.decide.fyi
+# decide.fyi
 
-> Deterministic refund eligibility notary for US consumer subscriptions
+> Deterministic subscription decision notaries for US consumers
 
-[![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)](https://refund.decide.fyi)
+[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](https://decide.fyi)
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
-[![Vendors](https://img.shields.io/badge/vendors-64-orange.svg)](https://refund.decide.fyi)
+[![Vendors](https://img.shields.io/badge/vendors-64-orange.svg)](https://decide.fyi)
+
+## MCP Servers
+
+| Server | Domain | Tool | Verdicts |
+|--------|--------|------|----------|
+| **Refund Notary** | [refund.decide.fyi](https://refund.decide.fyi) | `refund_eligibility` | ALLOWED / DENIED / UNKNOWN |
+| **Cancel Notary** | [cancel.decide.fyi](https://cancel.decide.fyi) | `cancellation_penalty` | FREE_CANCEL / PENALTY / LOCKED / UNKNOWN |
+| **Return Notary** | [return.decide.fyi](https://return.decide.fyi) | `return_eligibility` | RETURNABLE / EXPIRED / NON_RETURNABLE / UNKNOWN |
+| **Trial Notary** | [trial.decide.fyi](https://trial.decide.fyi) | `trial_terms` | TRIAL_AVAILABLE / NO_TRIAL / UNKNOWN |
+
+All servers: 64 vendors, US region, individual plans, stateless, no auth, 100 req/min.
 
 ## Quick Start
 
-```bash
-curl -X POST https://refund.decide.fyi/api/v1/refund/eligibility \
-  -H "Content-Type: application/json" \
-  -d '{"vendor":"adobe","days_since_purchase":12,"region":"US","plan":"individual"}'
+### Connect via MCP (Claude Desktop / Cursor / Windsurf)
+
+```json
+{
+  "mcpServers": {
+    "refund-decide": { "url": "https://refund.decide.fyi/api/mcp" },
+    "cancel-decide": { "url": "https://cancel.decide.fyi/api/mcp" },
+    "return-decide": { "url": "https://return.decide.fyi/api/mcp" },
+    "trial-decide":  { "url": "https://trial.decide.fyi/api/mcp" }
+  }
+}
 ```
-
-**Response:** `{"refundable":true,"verdict":"ALLOWED","code":"WITHIN_WINDOW",...}`
-
-No auth required. 100 req/min rate limit. [See all examples ->](client/EXAMPLES.md)
-
----
-
-## Overview
-
-**refund.decide.fyi** is a stateless, deterministic API that provides authoritative refund eligibility signals for US consumer subscriptions. It returns one of three verdicts:
-
-- **ALLOWED** - Refund is within the vendor's refund window
-- **DENIED** - Refund window has expired or vendor doesn't offer refunds
-- **UNKNOWN** - Unable to determine eligibility (unsupported vendor, region, or plan)
-
-Perfect for:
-- AI agents that need reliable refund policy data
-- Customer support tools
-- Financial applications
-- Subscription management platforms
-
-## Data Freshness
-
-Refund policies are sourced from official vendor documentation and terms of service. To keep data reliable:
-
-- **Daily automated checks** - A GitHub Action runs every day at 08:00 UTC, fetching each vendor's refund policy page, hashing the content, and comparing against stored baselines. If a page changes, an issue is automatically opened for review.
-- **Policy source URLs tracked** - Every vendor entry has a corresponding source URL in `rules/policy-sources.json` linking to the official policy page.
-- **Versioned rules** - The `rules_version` field in `rules/v1_us_individual.json` is bumped on every policy update so consumers can detect stale data.
-
-**Rules version:** `2026-02-01` | **Last updated:** 2026-02-01
-
-## API Endpoints
 
 ### REST API
 
-**Endpoint:** `https://refund.decide.fyi/api/v1/refund/eligibility`
+```bash
+# Refund eligibility
+curl -X POST https://refund.decide.fyi/api/v1/refund/eligibility \
+  -H "Content-Type: application/json" \
+  -d '{"vendor":"adobe","days_since_purchase":12,"region":"US","plan":"individual"}'
 
-**Method:** POST
+# Cancellation penalty
+curl -X POST https://cancel.decide.fyi/api/v1/cancel/penalty \
+  -H "Content-Type: application/json" \
+  -d '{"vendor":"adobe","region":"US","plan":"individual"}'
 
-**Request Body:**
-```json
-{
-  "vendor": "adobe",
-  "days_since_purchase": 12,
-  "region": "US",
-  "plan": "individual"
-}
+# Return eligibility
+curl -X POST https://return.decide.fyi/api/v1/return/eligibility \
+  -H "Content-Type: application/json" \
+  -d '{"vendor":"adobe","days_since_purchase":12,"region":"US","plan":"individual"}'
+
+# Trial terms
+curl -X POST https://trial.decide.fyi/api/v1/trial/terms \
+  -H "Content-Type: application/json" \
+  -d '{"vendor":"adobe","region":"US","plan":"individual"}'
 ```
 
-**Response (Success):**
+---
+
+## Refund Notary
+
+**Endpoint:** `POST https://refund.decide.fyi/api/v1/refund/eligibility`
+**MCP Tool:** `refund_eligibility`
+
+Checks if a subscription purchase is within the vendor's refund window.
+
+**Input:** `vendor`, `days_since_purchase`, `region`, `plan`
+
 ```json
-{
-  "refundable": true,
-  "verdict": "ALLOWED",
-  "code": "WITHIN_WINDOW",
-  "message": "Refund is allowed. Purchase is 12 day(s) old, within 14 day window.",
-  "rules_version": "2026-02-01",
-  "vendor": "adobe",
-  "window_days": 14,
-  "days_since_purchase": 12
-}
+{"refundable":true,"verdict":"ALLOWED","code":"WITHIN_WINDOW","message":"Refund is allowed. Purchase is 12 day(s) old, within 14 day window.","vendor":"adobe","window_days":14}
 ```
 
-**Response (Denied):**
+**Codes:** `WITHIN_WINDOW`, `OUTSIDE_WINDOW`, `NO_REFUNDS`, `UNSUPPORTED_VENDOR`
+
+## Cancel Notary
+
+**Endpoint:** `POST https://cancel.decide.fyi/api/v1/cancel/penalty`
+**MCP Tool:** `cancellation_penalty`
+
+Checks cancellation penalties — early termination fees, contract locks, or free cancellation.
+
+**Input:** `vendor`, `region`, `plan`
+
 ```json
-{
-  "refundable": false,
-  "verdict": "DENIED",
-  "code": "OUTSIDE_WINDOW",
-  "message": "Refund window expired. Purchase is 20 day(s) old, exceeds 14 day window.",
-  "rules_version": "2026-02-01",
-  "vendor": "adobe",
-  "window_days": 14,
-  "days_since_purchase": 20
-}
+{"verdict":"PENALTY","code":"EARLY_TERMINATION_FEE","message":"adobe charges an early termination fee: 50% of remaining months on annual plan.","vendor":"adobe","policy":"etf"}
 ```
 
-**Response (No Refunds):**
+**Codes:** `NO_PENALTY`, `EARLY_TERMINATION_FEE`, `CONTRACT_LOCKED`, `UNSUPPORTED_VENDOR`
+
+## Return Notary
+
+**Endpoint:** `POST https://return.decide.fyi/api/v1/return/eligibility`
+**MCP Tool:** `return_eligibility`
+
+Checks if a subscription purchase can be returned/reversed, with return type and method.
+
+**Input:** `vendor`, `days_since_purchase`, `region`, `plan`
+
 ```json
-{
-  "refundable": false,
-  "verdict": "DENIED",
-  "code": "NO_REFUNDS",
-  "message": "spotify does not offer refunds for individual plans",
-  "rules_version": "2026-02-01",
-  "vendor": "spotify",
-  "window_days": 0
-}
+{"returnable":true,"verdict":"RETURNABLE","code":"FULL_RETURN","message":"Return is available. Purchase is 5 day(s) old, within 14-day window.","vendor":"adobe","return_type":"full_refund","method":"self_service"}
 ```
 
-### MCP Server
+**Codes:** `FULL_RETURN`, `PRORATED_RETURN`, `CREDIT_RETURN`, `OUTSIDE_WINDOW`, `NO_RETURNS`, `UNSUPPORTED_VENDOR`
 
-**Endpoint:** `https://refund.decide.fyi/api/mcp`
+## Trial Notary
 
-**Protocol:** Model Context Protocol (JSON-RPC 2.0)
+**Endpoint:** `POST https://trial.decide.fyi/api/v1/trial/terms`
+**MCP Tool:** `trial_terms`
 
-**Tool Name:** `refund_eligibility`
+Checks free trial availability, length, card requirement, and auto-conversion status.
 
-The MCP server implements the full MCP specification with the following methods:
-- `initialize` - Protocol negotiation
-- `tools/list` - List available tools
-- `tools/call` - Execute refund eligibility check
+**Input:** `vendor`, `region`, `plan`
+
+```json
+{"verdict":"TRIAL_AVAILABLE","code":"AUTO_CONVERTS","message":"adobe offers a 7-day free trial. Credit card required. Auto-converts to paid plan.","vendor":"adobe","trial_days":7,"card_required":true,"auto_converts":true}
+```
+
+**Codes:** `AUTO_CONVERTS`, `NO_AUTO_CONVERT`, `TRIAL_NOT_AVAILABLE`, `UNSUPPORTED_VENDOR`
+
+---
 
 ## Supported Vendors (64)
 
-| Vendor | Identifier | Refund Window |
-|--------|-----------|---------------|
-| 1Password | `1password` | No refunds |
-| Adobe | `adobe` | 14 days |
-| Amazon Prime | `amazon_prime` | 3 days |
-| Apple App Store | `apple_app_store` | 14 days |
-| Apple Music | `apple_music` | No refunds |
-| Apple TV+ | `apple_tv_plus` | No refunds |
-| Audible | `audible` | No refunds |
-| Bitwarden | `bitwarden` | 30 days |
-| Bumble | `bumble` | No refunds |
-| Calm | `calm` | 30 days |
-| Canva | `canva` | No refunds |
-| ChatGPT Plus | `chatgpt_plus` | No refunds |
-| Claude Pro | `claude_pro` | No refunds |
-| Coursera Plus | `coursera_plus` | 14 days |
-| Crunchyroll | `crunchyroll` | No refunds |
-| Deezer | `deezer` | No refunds |
-| Disney+ | `disney_plus` | No refunds |
-| DoorDash DashPass | `doordash_dashpass` | No refunds |
-| Dropbox (US) | `dropbox_us` | No refunds |
-| Duolingo | `duolingo` | No refunds |
-| Evernote | `evernote` | 20 days |
-| ExpressVPN | `expressvpn` | 30 days |
-| Figma | `figma` | No refunds |
-| Fubo TV | `fubo_tv` | No refunds |
-| GitHub Pro | `github_pro` | No refunds |
-| Google Play | `google_play` | 2 days |
-| Grammarly | `grammarly` | No refunds |
-| Headspace | `headspace` | No refunds |
-| HelloFresh | `hellofresh` | No refunds |
-| Hinge | `hinge` | No refunds |
-| Hulu | `hulu` | No refunds |
-| iCloud+ | `icloud_plus` | 14 days |
-| Instacart+ | `instacart_plus` | 5 days |
-| LinkedIn Premium | `linkedin_premium` | 7 days |
-| MasterClass | `masterclass` | 30 days |
-| Max (HBO) | `max` | No refunds |
-| Microsoft 365 | `microsoft_365` | 30 days |
-| Midjourney | `midjourney` | No refunds |
-| Netflix | `netflix` | No refunds |
-| Nintendo Switch Online | `nintendo_switch_online` | No refunds |
-| Noom | `noom` | 14 days |
-| NordVPN | `nordvpn` | 30 days |
-| Notion | `notion` | 3 days |
-| Paramount+ | `paramount_plus` | No refunds |
-| Peacock | `peacock` | No refunds |
-| Peloton | `peloton` | No refunds |
-| PlayStation Plus | `playstation_plus` | 14 days |
-| Scribd | `scribd` | 30 days |
-| Shutterstock | `shutterstock` | No refunds |
-| Slack | `slack` | No refunds |
-| Sling TV | `sling_tv` | No refunds |
-| Spotify | `spotify` | No refunds |
-| Squarespace | `squarespace` | 14 days |
-| Strava | `strava` | 14 days |
-| Surfshark | `surfshark` | 30 days |
-| Tidal | `tidal` | No refunds |
-| Tinder | `tinder` | No refunds |
-| Todoist | `todoist` | 30 days |
-| Twitch | `twitch` | No refunds |
-| Walmart+ | `walmart_plus` | No refunds |
-| Wix | `wix` | 14 days |
-| Xbox Game Pass | `xbox_game_pass` | 30 days |
-| YouTube Premium | `youtube_premium` | No refunds |
-| Zoom | `zoom` | No refunds |
+| Vendor | Identifier | Refund | Cancel | Return | Trial |
+|--------|-----------|--------|--------|--------|-------|
+| 1Password | `1password` | No refunds | Free | No return | 14d |
+| Adobe | `adobe` | 14d | ETF | 14d full | 7d |
+| Amazon Prime | `amazon_prime` | 3d | Free | 3d full | 30d |
+| Apple App Store | `apple_app_store` | 14d | Free | 14d full | - |
+| Apple Music | `apple_music` | No refunds | Free | No return | 30d |
+| Apple TV+ | `apple_tv_plus` | No refunds | Free | No return | 7d |
+| Audible | `audible` | No refunds | Free | No return | 30d |
+| Bitwarden | `bitwarden` | 30d | Free | 30d full | 7d |
+| Bumble | `bumble` | No refunds | Free | No return | 7d |
+| Calm | `calm` | 30d | Free | 30d full | 7d |
+| Canva | `canva` | No refunds | Free | No return | 30d |
+| ChatGPT Plus | `chatgpt_plus` | No refunds | Free | No return | - |
+| Claude Pro | `claude_pro` | No refunds | Free | No return | - |
+| Coursera Plus | `coursera_plus` | 14d | Free | 14d full | 7d |
+| Crunchyroll | `crunchyroll` | No refunds | Free | No return | 7d |
+| Deezer | `deezer` | No refunds | Free | No return | 30d |
+| Disney+ | `disney_plus` | No refunds | Free | No return | - |
+| DoorDash DashPass | `doordash_dashpass` | No refunds | Free | No return | 30d |
+| Dropbox (US) | `dropbox_us` | No refunds | Free | No return | 30d |
+| Duolingo | `duolingo` | No refunds | Free | No return | 14d |
+| Evernote | `evernote` | 20d | Free | 20d full | 14d |
+| ExpressVPN | `expressvpn` | 30d | Free | 30d full | 7d |
+| Figma | `figma` | No refunds | Free | No return | 30d |
+| Fubo TV | `fubo_tv` | No refunds | Free | No return | 7d |
+| GitHub Pro | `github_pro` | No refunds | Free | No return | - |
+| Google Play | `google_play` | 2d | Free | 2d full | - |
+| Grammarly | `grammarly` | No refunds | Free | No return | 7d |
+| Headspace | `headspace` | No refunds | Free | No return | 7d |
+| HelloFresh | `hellofresh` | No refunds | Free (5d notice) | No return | - |
+| Hinge | `hinge` | No refunds | Free | No return | 7d |
+| Hulu | `hulu` | No refunds | Free | No return | 30d |
+| iCloud+ | `icloud_plus` | 14d | Free | 14d full | - |
+| Instacart+ | `instacart_plus` | 5d | Free | 5d full | 14d |
+| LinkedIn Premium | `linkedin_premium` | 7d | Free | 7d full | 30d |
+| MasterClass | `masterclass` | 30d | Free | 30d full | - |
+| Max (HBO) | `max` | No refunds | Free | No return | - |
+| Microsoft 365 | `microsoft_365` | 30d | Free | 30d full | 30d |
+| Midjourney | `midjourney` | No refunds | Free | No return | - |
+| Netflix | `netflix` | No refunds | Free | No return | - |
+| Nintendo Switch Online | `nintendo_switch_online` | No refunds | Free | No return | 7d |
+| Noom | `noom` | 14d | Free | 14d full | 7d |
+| NordVPN | `nordvpn` | 30d | Free | 30d full | 7d |
+| Notion | `notion` | 3d | Free | 3d full | - |
+| Paramount+ | `paramount_plus` | No refunds | Free | No return | 7d |
+| Peacock | `peacock` | No refunds | Free | No return | 7d |
+| Peloton | `peloton` | No refunds | Free | No return | 30d |
+| PlayStation Plus | `playstation_plus` | 14d | Free | 14d prorated | 14d |
+| Scribd | `scribd` | 30d | Free | 30d full | 30d |
+| Shutterstock | `shutterstock` | No refunds | ETF | No return | 30d |
+| Slack | `slack` | No refunds | Free | Credit | 90d |
+| Sling TV | `sling_tv` | No refunds | Free | No return | - |
+| Spotify | `spotify` | No refunds | Free | No return | 30d |
+| Squarespace | `squarespace` | 14d | Free | 14d full | 14d |
+| Strava | `strava` | 14d | Free | 14d full | 30d |
+| Surfshark | `surfshark` | 30d | Free | 30d full | 7d |
+| Tidal | `tidal` | No refunds | Free | No return | 30d |
+| Tinder | `tinder` | No refunds | Free | No return | - |
+| Todoist | `todoist` | 30d | Free | 30d full | 30d |
+| Twitch | `twitch` | No refunds | Free | No return | - |
+| Walmart+ | `walmart_plus` | No refunds | Free | No return | 30d |
+| Wix | `wix` | 14d | Free | 14d full | 14d |
+| Xbox Game Pass | `xbox_game_pass` | 30d | Free | 30d full | 14d |
+| YouTube Premium | `youtube_premium` | No refunds | Free | No return | 30d |
+| Zoom | `zoom` | No refunds | Free | No return | - |
 
 **Scope:** US region, individual plans only.
 
-## Response Codes
+## Data Freshness
 
-| Code | Description |
-|------|-------------|
-| `WITHIN_WINDOW` | Purchase is within refund window - refund allowed |
-| `OUTSIDE_WINDOW` | Purchase exceeds refund window - refund denied |
-| `NO_REFUNDS` | Vendor does not offer refunds for this plan type |
-| `UNSUPPORTED_VENDOR` | Vendor not in our database |
-| `NON_US_REGION` | Region other than US (not yet supported) |
-| `NON_INDIVIDUAL_PLAN` | Plan type other than individual (not yet supported) |
-| `INVALID_DAYS_SINCE_PURCHASE` | days_since_purchase must be non-negative number |
-| `MISSING_VENDOR` | vendor field is required |
-| `MISSING_REGION` | region field is required |
-| `MISSING_PLAN` | plan field is required |
+Policies are sourced from official vendor documentation and terms of service.
 
-## Usage Examples
-
-### cURL
-
-```bash
-curl -X POST https://refund.decide.fyi/api/v1/refund/eligibility \
-  -H "Content-Type: application/json" \
-  -d '{
-    "vendor": "adobe",
-    "days_since_purchase": 12,
-    "region": "US",
-    "plan": "individual"
-  }'
-```
-
-### JavaScript (fetch)
-
-```javascript
-const response = await fetch('https://refund.decide.fyi/api/v1/refund/eligibility', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({
-    vendor: 'adobe',
-    days_since_purchase: 12,
-    region: 'US',
-    plan: 'individual'
-  })
-});
-
-const result = await response.json();
-console.log(result.verdict); // "ALLOWED" or "DENIED" or "UNKNOWN"
-```
-
-### Node.js Client
-
-Requires Node 18+.
-
-```bash
-node client/refund-auditor.js adobe 12
-node client/refund-auditor.js spotify 1
-node client/refund-auditor.js microsoft_365 25
-```
-
-### Python
-
-```python
-import requests
-
-response = requests.post('https://refund.decide.fyi/api/v1/refund/eligibility', json={
-    'vendor': 'adobe',
-    'days_since_purchase': 12,
-    'region': 'US',
-    'plan': 'individual'
-})
-
-result = response.json()
-print(f"Verdict: {result['verdict']}")
-```
-
-## Error Handling
-
-### HTTP Status Codes
-
-- `200` - Success (check `verdict` field for eligibility result)
-- `400` - Bad Request (invalid JSON or malformed request)
-- `405` - Method Not Allowed (only POST is supported)
-- `500` - Internal Server Error
-
-### Error Response Format
-
-```json
-{
-  "ok": false,
-  "request_id": "abc123",
-  "error": "INVALID_JSON",
-  "message": "Request body must be valid JSON"
-}
-```
+- **Daily automated checks** — GitHub Action runs at 08:00 UTC, hashing vendor policy pages across all 4 services (refund, cancel, return, trial). If a page changes, an issue is opened for review.
+- **Policy source URLs tracked** — Each service has its own sources file in `rules/` linking to official policy pages.
+- **Versioned rules** — Each rules file includes a `rules_version` field for staleness detection.
 
 ## Architecture
 
-- **Stateless** - No database, no sessions, no side effects
-- **Deterministic** - Same input always produces same output
-- **Versioned Rules** - Rules file includes version for tracking changes
-- **Daily Monitoring** - GitHub Action checks vendor policy pages daily for changes
-- **Serverless** - Runs on Vercel Edge Functions for global low latency
-- **Zero Dependencies** - Core compute logic has no external dependencies
+- **Stateless** — No database, no sessions, no side effects
+- **Deterministic** — Same input always produces same output
+- **Versioned Rules** — Rules files include version for tracking changes
+- **Daily Monitoring** — GitHub Action checks all vendor policy pages daily
+- **Serverless** — Runs on Vercel serverless functions
+- **Zero Dependencies** — Core compute logic has no external dependencies
+- **Hostname Routing** — Vercel middleware routes subdomains to correct MCP endpoints
 
 ## Limitations
 
-- **US Only** - Currently only supports US region
-- **Individual Plans Only** - Business/enterprise plans not yet supported
-- **Calendar Days** - Refund windows are based on calendar days, not business days
-- **No Pro-rating** - Does not calculate partial refunds or pro-rated amounts
-- **Static Rules** - Does not account for promotional offers or special circumstances
+- **US Only** — Currently only supports US region
+- **Individual Plans Only** — Business/enterprise plans not yet supported
+- **Calendar Days** — Windows are based on calendar days, not business days
+- **Static Rules** — Does not account for promotional offers or special circumstances
 
 ## Changelog
+
+### v1.2.0 (2026-02-02)
+
+**Added:**
+- Cancel Notary MCP (cancel.decide.fyi) — cancellation penalty checker
+- Return Notary MCP (return.decide.fyi) — return eligibility checker
+- Trial Notary MCP (trial.decide.fyi) — free trial terms checker
+- Hostname-based middleware routing for all subdomains
+- Policy source files and daily checking for cancel, return, and trial policies
+- Humans/Agents mode toggle on landing page
+- MCP catalog with cards for all 4 servers
+
+**Fixed:**
+- Daily policy checker: added `contents:write` permission and fixed shell logic
+- Removed dead Cloudflare email-decode scripts causing 404s
 
 ### v1.1.0 (2026-02-01)
 
 **Added:**
 - Expanded from 9 to 64 supported vendors
-- Daily policy-check GitHub Action (cron at 08:00 UTC) that detects vendor policy page changes and opens issues automatically
-- Policy source URLs tracked in `rules/policy-sources.json` for every vendor
-- New categories: streaming, dating, delivery, education, wellness, fitness, AI, VPN, security, design, food
+- Daily policy-check GitHub Action (cron at 08:00 UTC)
+- Policy source URLs tracked in `rules/policy-sources.json`
+- MCP vendor `enum` in inputSchema for agent discoverability
 
 **Fixed:**
-- Fixed `ERR_IMPORT_ATTRIBUTE_MISSING` crash on Vercel caused by Node 22 requiring import attributes for JSON imports
+- `ERR_IMPORT_ATTRIBUTE_MISSING` crash on Vercel (Node 22 import attributes)
 
 ### v1.0.0 (2026-01-15)
 
 **Added:**
-- Initial release
-- REST API endpoint
-- MCP server implementation
-- Support for 9 major vendors (Adobe, Spotify, Netflix, Microsoft 365, Apple App Store, Google Play, Notion, Canva, Dropbox)
-- Comprehensive input validation
-- Descriptive error messages
-- Shared compute module
-
-**Fixed:**
-- Removed broken Amazon Prime vendor
-- Removed unused `mode` field from rules
-- Improved error handling and JSON parsing
-- Deduplicated compute logic between REST and MCP endpoints
-
-## Contributing
-
-Found incorrect refund policy data? Want to add a new vendor?
-
-1. Check the vendor's official refund policy documentation
-2. Open an issue with the policy details and source links
-3. We'll verify and update the rules file
+- Initial release with REST API and MCP server
+- Support for 9 vendors
 
 ## Free API (No Auth)
 
-**This API is currently free to use. No authentication. No API keys.**
+All 4 servers are free to use. No authentication. No API keys.
 
 Rate limit: 100 requests/minute per IP.
 
 Questions? [decidefyi@gmail.com](mailto:decidefyi@gmail.com) or [@decidefyi on X](https://x.com/decidefyi)
 
-## License
-
-Rules data is provided as-is for informational purposes only. Always verify refund eligibility with the vendor directly before making decisions.
-
 ## Links
 
 - **Website:** [https://decide.fyi](https://decide.fyi)
-- **Refund API:** [https://refund.decide.fyi](https://refund.decide.fyi)
-- **Smithery:** [https://smithery.ai/server/refund-decide/notary](https://smithery.ai/server/refund-decide/notary)
+- **Refund:** [https://refund.decide.fyi](https://refund.decide.fyi)
+- **Cancel:** [https://cancel.decide.fyi](https://cancel.decide.fyi)
+- **Return:** [https://return.decide.fyi](https://return.decide.fyi)
+- **Trial:** [https://trial.decide.fyi](https://trial.decide.fyi)
 - **X/Twitter:** [@decidefyi](https://x.com/decidefyi)
 - **MCP Spec:** [https://modelcontextprotocol.io](https://modelcontextprotocol.io)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decide",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module"
 }

--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -1,11 +1,33 @@
 {
-  "name": "RefundDecide Notary",
-  "version": "1.1.0",
-  "description": "Deterministic refund eligibility notary for US consumer subscriptions. Outputs ALLOWED, DENIED, or UNKNOWN.",
-  "url": "https://refund.decide.fyi",
-  "endpoint": "https://refund.decide.fyi/api/v1/refund/eligibility",
-  "capabilities": [
-    "dev.ucp.notary.refund"
+  "name": "decide.fyi",
+  "version": "1.2.0",
+  "description": "Deterministic subscription decision notaries for US consumers. Four stateless MCP servers: refund, cancel, return, trial.",
+  "url": "https://decide.fyi",
+  "services": [
+    {
+      "name": "RefundDecide Notary",
+      "endpoint": "https://refund.decide.fyi/api/v1/refund/eligibility",
+      "mcp_url": "https://refund.decide.fyi/api/mcp",
+      "capabilities": ["dev.ucp.notary.refund"]
+    },
+    {
+      "name": "CancelDecide Notary",
+      "endpoint": "https://cancel.decide.fyi/api/v1/cancel/penalty",
+      "mcp_url": "https://cancel.decide.fyi/api/mcp",
+      "capabilities": ["dev.ucp.notary.cancel"]
+    },
+    {
+      "name": "ReturnDecide Notary",
+      "endpoint": "https://return.decide.fyi/api/v1/return/eligibility",
+      "mcp_url": "https://return.decide.fyi/api/mcp",
+      "capabilities": ["dev.ucp.notary.return"]
+    },
+    {
+      "name": "TrialDecide Notary",
+      "endpoint": "https://trial.decide.fyi/api/v1/trial/terms",
+      "mcp_url": "https://trial.decide.fyi/api/mcp",
+      "capabilities": ["dev.ucp.notary.trial"]
+    }
   ],
   "execution": {
     "mode": "stateless",
@@ -13,6 +35,6 @@
   },
   "auth": {
     "type": "none",
-    "note": "Public v1 notary. No authentication required."
+    "note": "Public v1 notaries. No authentication required."
   }
 }

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,12 +1,12 @@
 {
-  "name": "RefundDecide Notary",
-  "version": "1.1.0",
-  "description": "Deterministic refund eligibility notary for US consumer subscriptions. Stateless.",
+  "name": "decide.fyi",
+  "version": "1.2.0",
+  "description": "Deterministic subscription decision notaries for US consumers. Stateless.",
   "transports": [
-    {
-      "type": "streamable-http",
-      "url": "https://refund.decide.fyi/api/mcp"
-    }
+    { "type": "streamable-http", "url": "https://refund.decide.fyi/api/mcp" },
+    { "type": "streamable-http", "url": "https://cancel.decide.fyi/api/mcp" },
+    { "type": "streamable-http", "url": "https://return.decide.fyi/api/mcp" },
+    { "type": "streamable-http", "url": "https://trial.decide.fyi/api/mcp" }
   ],
   "capabilities": {
     "tools": true

--- a/public/.well-known/ucp.json
+++ b/public/.well-known/ucp.json
@@ -1,44 +1,62 @@
 {
-  "name": "refund.decide.fyi",
-  "type": "refund_eligibility_notary",
-  "version": "1.1.0",
-  "description": "Deterministic refund eligibility notary for US consumer subscriptions. Returns ALLOWED, DENIED, or UNKNOWN.",
-  "endpoint": {
-    "method": "POST",
-    "url": "https://refund.decide.fyi/api/v1/refund/eligibility",
-    "content_type": "application/json"
-  },
-  "inputs": {
-    "vendor": {
-      "type": "string",
-      "required": true,
-      "enum": ["1password", "adobe", "amazon_prime", "apple_app_store", "apple_music", "apple_tv_plus", "audible", "bitwarden", "bumble", "calm", "canva", "chatgpt_plus", "claude_pro", "coursera_plus", "crunchyroll", "deezer", "disney_plus", "doordash_dashpass", "dropbox_us", "duolingo", "evernote", "expressvpn", "figma", "fubo_tv", "github_pro", "google_play", "grammarly", "headspace", "hellofresh", "hinge", "hulu", "icloud_plus", "instacart_plus", "linkedin_premium", "masterclass", "max", "microsoft_365", "midjourney", "netflix", "nintendo_switch_online", "noom", "nordvpn", "notion", "paramount_plus", "peacock", "peloton", "playstation_plus", "scribd", "shutterstock", "slack", "sling_tv", "spotify", "squarespace", "strava", "surfshark", "tidal", "tinder", "todoist", "twitch", "walmart_plus", "wix", "xbox_game_pass", "youtube_premium", "zoom"]
+  "name": "decide.fyi",
+  "version": "1.2.0",
+  "description": "Deterministic subscription decision notaries for US consumers.",
+  "services": [
+    {
+      "name": "refund.decide.fyi",
+      "type": "refund_eligibility_notary",
+      "endpoint": { "method": "POST", "url": "https://refund.decide.fyi/api/v1/refund/eligibility" },
+      "mcp_url": "https://refund.decide.fyi/api/mcp",
+      "tool_name": "refund_eligibility",
+      "inputs": {
+        "vendor": { "type": "string", "required": true, "enum": ["1password","adobe","amazon_prime","apple_app_store","apple_music","apple_tv_plus","audible","bitwarden","bumble","calm","canva","chatgpt_plus","claude_pro","coursera_plus","crunchyroll","deezer","disney_plus","doordash_dashpass","dropbox_us","duolingo","evernote","expressvpn","figma","fubo_tv","github_pro","google_play","grammarly","headspace","hellofresh","hinge","hulu","icloud_plus","instacart_plus","linkedin_premium","masterclass","max","microsoft_365","midjourney","netflix","nintendo_switch_online","noom","nordvpn","notion","paramount_plus","peacock","peloton","playstation_plus","scribd","shutterstock","slack","sling_tv","spotify","squarespace","strava","surfshark","tidal","tinder","todoist","twitch","walmart_plus","wix","xbox_game_pass","youtube_premium","zoom"] },
+        "days_since_purchase": { "type": "number", "required": true, "minimum": 0 },
+        "region": { "type": "string", "required": true, "enum": ["US"] },
+        "plan": { "type": "string", "required": true, "enum": ["individual"] }
+      },
+      "outputs": { "verdict": ["ALLOWED", "DENIED", "UNKNOWN"] }
     },
-    "days_since_purchase": {
-      "type": "number",
-      "required": true,
-      "minimum": 0
+    {
+      "name": "cancel.decide.fyi",
+      "type": "cancellation_penalty_notary",
+      "endpoint": { "method": "POST", "url": "https://cancel.decide.fyi/api/v1/cancel/penalty" },
+      "mcp_url": "https://cancel.decide.fyi/api/mcp",
+      "tool_name": "cancellation_penalty",
+      "inputs": {
+        "vendor": { "type": "string", "required": true, "enum": ["1password","adobe","amazon_prime","apple_app_store","apple_music","apple_tv_plus","audible","bitwarden","bumble","calm","canva","chatgpt_plus","claude_pro","coursera_plus","crunchyroll","deezer","disney_plus","doordash_dashpass","dropbox_us","duolingo","evernote","expressvpn","figma","fubo_tv","github_pro","google_play","grammarly","headspace","hellofresh","hinge","hulu","icloud_plus","instacart_plus","linkedin_premium","masterclass","max","microsoft_365","midjourney","netflix","nintendo_switch_online","noom","nordvpn","notion","paramount_plus","peacock","peloton","playstation_plus","scribd","shutterstock","slack","sling_tv","spotify","squarespace","strava","surfshark","tidal","tinder","todoist","twitch","walmart_plus","wix","xbox_game_pass","youtube_premium","zoom"] },
+        "region": { "type": "string", "required": true, "enum": ["US"] },
+        "plan": { "type": "string", "required": true, "enum": ["individual"] }
+      },
+      "outputs": { "verdict": ["FREE_CANCEL", "PENALTY", "LOCKED", "UNKNOWN"] }
     },
-    "region": {
-      "type": "string",
-      "required": true,
-      "enum": ["US"]
+    {
+      "name": "return.decide.fyi",
+      "type": "return_eligibility_notary",
+      "endpoint": { "method": "POST", "url": "https://return.decide.fyi/api/v1/return/eligibility" },
+      "mcp_url": "https://return.decide.fyi/api/mcp",
+      "tool_name": "return_eligibility",
+      "inputs": {
+        "vendor": { "type": "string", "required": true, "enum": ["1password","adobe","amazon_prime","apple_app_store","apple_music","apple_tv_plus","audible","bitwarden","bumble","calm","canva","chatgpt_plus","claude_pro","coursera_plus","crunchyroll","deezer","disney_plus","doordash_dashpass","dropbox_us","duolingo","evernote","expressvpn","figma","fubo_tv","github_pro","google_play","grammarly","headspace","hellofresh","hinge","hulu","icloud_plus","instacart_plus","linkedin_premium","masterclass","max","microsoft_365","midjourney","netflix","nintendo_switch_online","noom","nordvpn","notion","paramount_plus","peacock","peloton","playstation_plus","scribd","shutterstock","slack","sling_tv","spotify","squarespace","strava","surfshark","tidal","tinder","todoist","twitch","walmart_plus","wix","xbox_game_pass","youtube_premium","zoom"] },
+        "days_since_purchase": { "type": "number", "required": true, "minimum": 0 },
+        "region": { "type": "string", "required": true, "enum": ["US"] },
+        "plan": { "type": "string", "required": true, "enum": ["individual"] }
+      },
+      "outputs": { "verdict": ["RETURNABLE", "EXPIRED", "NON_RETURNABLE", "UNKNOWN"] }
     },
-    "plan": {
-      "type": "string",
-      "required": true,
-      "enum": ["individual"]
+    {
+      "name": "trial.decide.fyi",
+      "type": "trial_terms_notary",
+      "endpoint": { "method": "POST", "url": "https://trial.decide.fyi/api/v1/trial/terms" },
+      "mcp_url": "https://trial.decide.fyi/api/mcp",
+      "tool_name": "trial_terms",
+      "inputs": {
+        "vendor": { "type": "string", "required": true, "enum": ["1password","adobe","amazon_prime","apple_app_store","apple_music","apple_tv_plus","audible","bitwarden","bumble","calm","canva","chatgpt_plus","claude_pro","coursera_plus","crunchyroll","deezer","disney_plus","doordash_dashpass","dropbox_us","duolingo","evernote","expressvpn","figma","fubo_tv","github_pro","google_play","grammarly","headspace","hellofresh","hinge","hulu","icloud_plus","instacart_plus","linkedin_premium","masterclass","max","microsoft_365","midjourney","netflix","nintendo_switch_online","noom","nordvpn","notion","paramount_plus","peacock","peloton","playstation_plus","scribd","shutterstock","slack","sling_tv","spotify","squarespace","strava","surfshark","tidal","tinder","todoist","twitch","walmart_plus","wix","xbox_game_pass","youtube_premium","zoom"] },
+        "region": { "type": "string", "required": true, "enum": ["US"] },
+        "plan": { "type": "string", "required": true, "enum": ["individual"] }
+      },
+      "outputs": { "verdict": ["TRIAL_AVAILABLE", "NO_TRIAL", "UNKNOWN"] }
     }
-  },
-  "outputs": {
-    "verdict": ["ALLOWED", "DENIED", "UNKNOWN"],
-    "code": "string",
-    "message": "string",
-    "rules_version": "string",
-    "window_days": "number"
-  },
-  "auth": {
-    "type": "none",
-    "rate_limit": "100 requests/minute per IP"
-  }
+  ],
+  "auth": { "type": "none", "rate_limit": "100 requests/minute per IP" }
 }

--- a/public/docs.json
+++ b/public/docs.json
@@ -1,93 +1,75 @@
 {
-  "service": "refund.decide.fyi",
-  "type": "refund_eligibility_notary",
-  "version": "1.1.0",
-  "description": "Deterministic refund eligibility notary for US consumer subscriptions. Returns ALLOWED, DENIED, or UNKNOWN.",
-  "endpoint": {
-    "method": "POST",
-    "url": "https://refund.decide.fyi/api/v1/refund/eligibility",
-    "content_type": "application/json"
-  },
-  "mcp_endpoint": {
-    "method": "POST",
-    "url": "https://refund.decide.fyi/api/mcp",
-    "protocol": "JSON-RPC 2.0 (Model Context Protocol)",
-    "tool_name": "refund_eligibility"
-  },
-  "inputs": {
-    "vendor": {
-      "type": "string",
-      "required": true,
-      "description": "Vendor identifier (lowercase, underscore-separated).",
-      "enum": ["1password", "adobe", "amazon_prime", "apple_app_store", "apple_music", "apple_tv_plus", "audible", "bitwarden", "bumble", "calm", "canva", "chatgpt_plus", "claude_pro", "coursera_plus", "crunchyroll", "deezer", "disney_plus", "doordash_dashpass", "dropbox_us", "duolingo", "evernote", "expressvpn", "figma", "fubo_tv", "github_pro", "google_play", "grammarly", "headspace", "hellofresh", "hinge", "hulu", "icloud_plus", "instacart_plus", "linkedin_premium", "masterclass", "max", "microsoft_365", "midjourney", "netflix", "nintendo_switch_online", "noom", "nordvpn", "notion", "paramount_plus", "peacock", "peloton", "playstation_plus", "scribd", "shutterstock", "slack", "sling_tv", "spotify", "squarespace", "strava", "surfshark", "tidal", "tinder", "todoist", "twitch", "walmart_plus", "wix", "xbox_game_pass", "youtube_premium", "zoom"]
+  "name": "decide.fyi",
+  "version": "1.2.0",
+  "description": "Deterministic subscription decision notaries for US consumers. Four MCP servers covering refund, cancel, return, and trial policies for 64 vendors.",
+  "services": [
+    {
+      "name": "refund.decide.fyi",
+      "type": "refund_eligibility_notary",
+      "description": "Refund eligibility checker. Returns ALLOWED, DENIED, or UNKNOWN based on vendor refund window.",
+      "endpoint": { "method": "POST", "url": "https://refund.decide.fyi/api/v1/refund/eligibility" },
+      "mcp_endpoint": { "method": "POST", "url": "https://refund.decide.fyi/api/mcp", "protocol": "JSON-RPC 2.0 (MCP)", "tool_name": "refund_eligibility" },
+      "inputs": {
+        "vendor": { "type": "string", "required": true, "enum": ["1password","adobe","amazon_prime","apple_app_store","apple_music","apple_tv_plus","audible","bitwarden","bumble","calm","canva","chatgpt_plus","claude_pro","coursera_plus","crunchyroll","deezer","disney_plus","doordash_dashpass","dropbox_us","duolingo","evernote","expressvpn","figma","fubo_tv","github_pro","google_play","grammarly","headspace","hellofresh","hinge","hulu","icloud_plus","instacart_plus","linkedin_premium","masterclass","max","microsoft_365","midjourney","netflix","nintendo_switch_online","noom","nordvpn","notion","paramount_plus","peacock","peloton","playstation_plus","scribd","shutterstock","slack","sling_tv","spotify","squarespace","strava","surfshark","tidal","tinder","todoist","twitch","walmart_plus","wix","xbox_game_pass","youtube_premium","zoom"] },
+        "days_since_purchase": { "type": "number", "required": true, "minimum": 0 },
+        "region": { "type": "string", "required": true, "enum": ["US"] },
+        "plan": { "type": "string", "required": true, "enum": ["individual"] }
+      },
+      "outputs": {
+        "verdict": { "enum": ["ALLOWED", "DENIED", "UNKNOWN"] },
+        "code": { "enum": ["WITHIN_WINDOW", "OUTSIDE_WINDOW", "NO_REFUNDS", "UNSUPPORTED_VENDOR", "NON_US_REGION", "NON_INDIVIDUAL_PLAN"] }
+      }
     },
-    "days_since_purchase": {
-      "type": "number",
-      "required": true,
-      "description": "Number of days since the subscription was purchased. Must be a non-negative integer.",
-      "minimum": 0
+    {
+      "name": "cancel.decide.fyi",
+      "type": "cancellation_penalty_notary",
+      "description": "Cancellation penalty checker. Returns FREE_CANCEL, PENALTY, or LOCKED based on vendor cancellation terms.",
+      "endpoint": { "method": "POST", "url": "https://cancel.decide.fyi/api/v1/cancel/penalty" },
+      "mcp_endpoint": { "method": "POST", "url": "https://cancel.decide.fyi/api/mcp", "protocol": "JSON-RPC 2.0 (MCP)", "tool_name": "cancellation_penalty" },
+      "inputs": {
+        "vendor": { "type": "string", "required": true, "enum": ["1password","adobe","amazon_prime","apple_app_store","apple_music","apple_tv_plus","audible","bitwarden","bumble","calm","canva","chatgpt_plus","claude_pro","coursera_plus","crunchyroll","deezer","disney_plus","doordash_dashpass","dropbox_us","duolingo","evernote","expressvpn","figma","fubo_tv","github_pro","google_play","grammarly","headspace","hellofresh","hinge","hulu","icloud_plus","instacart_plus","linkedin_premium","masterclass","max","microsoft_365","midjourney","netflix","nintendo_switch_online","noom","nordvpn","notion","paramount_plus","peacock","peloton","playstation_plus","scribd","shutterstock","slack","sling_tv","spotify","squarespace","strava","surfshark","tidal","tinder","todoist","twitch","walmart_plus","wix","xbox_game_pass","youtube_premium","zoom"] },
+        "region": { "type": "string", "required": true, "enum": ["US"] },
+        "plan": { "type": "string", "required": true, "enum": ["individual"] }
+      },
+      "outputs": {
+        "verdict": { "enum": ["FREE_CANCEL", "PENALTY", "LOCKED", "UNKNOWN"] },
+        "code": { "enum": ["NO_PENALTY", "EARLY_TERMINATION_FEE", "CONTRACT_LOCKED", "UNSUPPORTED_VENDOR", "NON_US_REGION", "NON_INDIVIDUAL_PLAN"] }
+      }
     },
-    "region": {
-      "type": "string",
-      "required": true,
-      "description": "Region code.",
-      "enum": ["US"]
+    {
+      "name": "return.decide.fyi",
+      "type": "return_eligibility_notary",
+      "description": "Return eligibility checker. Returns RETURNABLE, EXPIRED, or NON_RETURNABLE with return type and method.",
+      "endpoint": { "method": "POST", "url": "https://return.decide.fyi/api/v1/return/eligibility" },
+      "mcp_endpoint": { "method": "POST", "url": "https://return.decide.fyi/api/mcp", "protocol": "JSON-RPC 2.0 (MCP)", "tool_name": "return_eligibility" },
+      "inputs": {
+        "vendor": { "type": "string", "required": true, "enum": ["1password","adobe","amazon_prime","apple_app_store","apple_music","apple_tv_plus","audible","bitwarden","bumble","calm","canva","chatgpt_plus","claude_pro","coursera_plus","crunchyroll","deezer","disney_plus","doordash_dashpass","dropbox_us","duolingo","evernote","expressvpn","figma","fubo_tv","github_pro","google_play","grammarly","headspace","hellofresh","hinge","hulu","icloud_plus","instacart_plus","linkedin_premium","masterclass","max","microsoft_365","midjourney","netflix","nintendo_switch_online","noom","nordvpn","notion","paramount_plus","peacock","peloton","playstation_plus","scribd","shutterstock","slack","sling_tv","spotify","squarespace","strava","surfshark","tidal","tinder","todoist","twitch","walmart_plus","wix","xbox_game_pass","youtube_premium","zoom"] },
+        "days_since_purchase": { "type": "number", "required": true, "minimum": 0 },
+        "region": { "type": "string", "required": true, "enum": ["US"] },
+        "plan": { "type": "string", "required": true, "enum": ["individual"] }
+      },
+      "outputs": {
+        "verdict": { "enum": ["RETURNABLE", "EXPIRED", "NON_RETURNABLE", "UNKNOWN"] },
+        "code": { "enum": ["FULL_RETURN", "PRORATED_RETURN", "CREDIT_RETURN", "OUTSIDE_WINDOW", "NO_RETURNS", "UNSUPPORTED_VENDOR", "NON_US_REGION", "NON_INDIVIDUAL_PLAN"] }
+      }
     },
-    "plan": {
-      "type": "string",
-      "required": true,
-      "description": "Plan type.",
-      "enum": ["individual"]
+    {
+      "name": "trial.decide.fyi",
+      "type": "trial_terms_notary",
+      "description": "Free trial terms checker. Returns TRIAL_AVAILABLE or NO_TRIAL with trial length, card requirement, and auto-conversion status.",
+      "endpoint": { "method": "POST", "url": "https://trial.decide.fyi/api/v1/trial/terms" },
+      "mcp_endpoint": { "method": "POST", "url": "https://trial.decide.fyi/api/mcp", "protocol": "JSON-RPC 2.0 (MCP)", "tool_name": "trial_terms" },
+      "inputs": {
+        "vendor": { "type": "string", "required": true, "enum": ["1password","adobe","amazon_prime","apple_app_store","apple_music","apple_tv_plus","audible","bitwarden","bumble","calm","canva","chatgpt_plus","claude_pro","coursera_plus","crunchyroll","deezer","disney_plus","doordash_dashpass","dropbox_us","duolingo","evernote","expressvpn","figma","fubo_tv","github_pro","google_play","grammarly","headspace","hellofresh","hinge","hulu","icloud_plus","instacart_plus","linkedin_premium","masterclass","max","microsoft_365","midjourney","netflix","nintendo_switch_online","noom","nordvpn","notion","paramount_plus","peacock","peloton","playstation_plus","scribd","shutterstock","slack","sling_tv","spotify","squarespace","strava","surfshark","tidal","tinder","todoist","twitch","walmart_plus","wix","xbox_game_pass","youtube_premium","zoom"] },
+        "region": { "type": "string", "required": true, "enum": ["US"] },
+        "plan": { "type": "string", "required": true, "enum": ["individual"] }
+      },
+      "outputs": {
+        "verdict": { "enum": ["TRIAL_AVAILABLE", "NO_TRIAL", "UNKNOWN"] },
+        "code": { "enum": ["AUTO_CONVERTS", "NO_AUTO_CONVERT", "TRIAL_NOT_AVAILABLE", "UNSUPPORTED_VENDOR", "NON_US_REGION", "NON_INDIVIDUAL_PLAN"] }
+      }
     }
-  },
-  "outputs": {
-    "verdict": {
-      "type": "string",
-      "enum": ["ALLOWED", "DENIED", "UNKNOWN"],
-      "description": "Refund eligibility verdict."
-    },
-    "code": {
-      "type": "string",
-      "enum": ["WITHIN_WINDOW", "OUTSIDE_WINDOW", "NO_REFUNDS", "UNSUPPORTED_VENDOR", "NON_US_REGION", "NON_INDIVIDUAL_PLAN", "INVALID_DAYS_SINCE_PURCHASE", "MISSING_VENDOR", "MISSING_REGION", "MISSING_PLAN"],
-      "description": "Machine-readable result code."
-    },
-    "message": {
-      "type": "string",
-      "description": "Human-readable explanation of the result."
-    },
-    "rules_version": {
-      "type": "string",
-      "description": "Version of the rules data used for this response."
-    },
-    "window_days": {
-      "type": "number",
-      "description": "Refund window in days for the vendor (0 means no refunds)."
-    }
-  },
-  "execution": {
-    "stateless": true,
-    "side_effects": "none"
-  },
-  "auth": {
-    "type": "none",
-    "rate_limit": "100 requests/minute per IP"
-  },
-  "example": {
-    "request": {
-      "vendor": "adobe",
-      "days_since_purchase": 12,
-      "region": "US",
-      "plan": "individual"
-    },
-    "response": {
-      "refundable": true,
-      "verdict": "ALLOWED",
-      "code": "WITHIN_WINDOW",
-      "message": "Refund is allowed. Purchase is 12 day(s) old, within 14 day window.",
-      "rules_version": "2026-02-01",
-      "vendor": "adobe",
-      "window_days": 14,
-      "days_since_purchase": 12
-    }
-  }
+  ],
+  "execution": { "stateless": true, "side_effects": "none" },
+  "auth": { "type": "none", "rate_limit": "100 requests/minute per IP" }
 }

--- a/server.json
+++ b/server.json
@@ -1,16 +1,16 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.decidefyi/refund-decide",
-  "description": "Refund eligibility notary for US subscriptions. Returns ALLOWED/DENIED/UNKNOWN.",
+  "name": "io.github.decidefyi/decide",
+  "description": "Subscription decision notaries for US consumers. 4 tools: refund, cancel, return, trial.",
   "repository": {
     "url": "https://github.com/decidefyi/decide",
     "source": "github"
   },
-  "version": "1.1.0",
+  "version": "1.2.0",
   "remotes": [
-    {
-      "url": "https://refund.decide.fyi/api/mcp",
-      "type": "streamable-http"
-    }
+    { "url": "https://refund.decide.fyi/api/mcp", "type": "streamable-http" },
+    { "url": "https://cancel.decide.fyi/api/mcp", "type": "streamable-http" },
+    { "url": "https://return.decide.fyi/api/mcp", "type": "streamable-http" },
+    { "url": "https://trial.decide.fyi/api/mcp", "type": "streamable-http" }
   ]
 }


### PR DESCRIPTION
- README: rewritten to cover refund, cancel, return, and trial; added unified vendor table with all 4 policy columns, MCP connect config, and REST examples for each service
- docs.json / ucp.json: expanded from single refund service to all 4 services with full input schemas and vendor enums
- agent-card.json / server-card.json / server.json: updated to list all 4 MCP transport URLs
- package.json: bumped version 1.1.0 → 1.2.0

https://claude.ai/code/session_01StXcqNGaLU8ssafdwvAfaT