### PR TITLE
Fix dark mode two-tone shade caused by transparent sections

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -186,7 +186,7 @@
         @keyframes scroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
 
         /* SECTIONS */
-        section{position:relative;z-index:2}
+        section{position:relative;z-index:2;background:var(--bg)}
         .sec-light{background:var(--bg)}
         .sec-dark{background:var(--bg-dark);color:var(--fg-light)}
         .sec-dark .sec-head h2{color:var(--fg-light)}


### PR DESCRIPTION
Add background:var(--bg) to base section rule so the fixed canvas element doesn't bleed through sections without explicit backgrounds.

https://claude.ai/code/session_01StXcqNGaLU8ssafdwvAfaT