### PR TITLE
Add one-click install badges for Cursor and VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@
 [![MCP](https://img.shields.io/badge/MCP-compatible-green.svg)](https://modelcontextprotocol.io)
 [![Vendors](https://img.shields.io/badge/vendors-64-orange.svg)](https://decide.fyi)
 
+## One-Click Install
+
+**Refund Notary** — refund eligibility checker
+
+[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.png)](cursor://anysphere.cursor-deeplink/mcp/install?name=refund-decide&config=eyJ1cmwiOiAiaHR0cHM6Ly9yZWZ1bmQuZGVjaWRlLmZ5aS9hcGkvbWNwIn0=) [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=refund-decide&config=%7B%22type%22%3A%20%22http%22%2C%20%22url%22%3A%20%22https%3A//refund.decide.fyi/api/mcp%22%7D)
+
+**Cancel Notary** — cancellation penalty checker
+
+[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.png)](cursor://anysphere.cursor-deeplink/mcp/install?name=cancel-decide&config=eyJ1cmwiOiAiaHR0cHM6Ly9jYW5jZWwuZGVjaWRlLmZ5aS9hcGkvbWNwIn0=) [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=cancel-decide&config=%7B%22type%22%3A%20%22http%22%2C%20%22url%22%3A%20%22https%3A//cancel.decide.fyi/api/mcp%22%7D)
+
+**Return Notary** — return eligibility checker
+
+[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.png)](cursor://anysphere.cursor-deeplink/mcp/install?name=return-decide&config=eyJ1cmwiOiAiaHR0cHM6Ly9yZXR1cm4uZGVjaWRlLmZ5aS9hcGkvbWNwIn0=) [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=return-decide&config=%7B%22type%22%3A%20%22http%22%2C%20%22url%22%3A%20%22https%3A//return.decide.fyi/api/mcp%22%7D)
+
+**Trial Notary** — free trial terms checker
+
+[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.png)](cursor://anysphere.cursor-deeplink/mcp/install?name=trial-decide&config=eyJ1cmwiOiAiaHR0cHM6Ly90cmlhbC5kZWNpZGUuZnlpL2FwaS9tY3AifQ==) [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=trial-decide&config=%7B%22type%22%3A%20%22http%22%2C%20%22url%22%3A%20%22https%3A//trial.decide.fyi/api/mcp%22%7D)
+
 ## MCP Servers
 
 | Server | Domain | Tool | Verdicts |
@@ -19,7 +37,7 @@ All servers: 64 vendors, US region, individual plans, stateless, no auth, 100 re
 
 ## Quick Start
 
-### Connect via MCP (Claude Desktop / Cursor / Windsurf)
+### Connect via MCP (Claude Desktop / Windsurf / other clients)
 
 ```json
 {


### PR DESCRIPTION
- Cursor deeplink badges using official cursor.com badge images
- VS Code install badges using shields.io with vscode deeplinks
- Badges for all 4 MCP servers (refund, cancel, return, trial)
- JSON config section updated to reference other clients

https://claude.ai/code/session_01StXcqNGaLU8ssafdwvAfaT