### PR TITLE
Fix local middleware recursion, rate-limit isolation, and add smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ logs/
 
 # MCP Registry tokens (sensitive credentials)
 .mcpregistry_*
+.env*.local

--- a/api/decide.js
+++ b/api/decide.js
@@ -79,7 +79,17 @@ export default async function handler(req, res) {
       const qp = req.query?.question ?? "";
       question = Array.isArray(qp) ? qp[0] : qp;
     } else if (req.method === "POST") {
-      const body = typeof req.body === "string" ? JSON.parse(req.body) : (req.body || {});
+      let body = req.body || {};
+      if (typeof req.body === "string") {
+        try {
+          body = JSON.parse(req.body);
+        } catch {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ c: "unclear", v: "Invalid JSON body", request_id }));
+          return;
+        }
+      }
       question = body.question || "";
     } else {
       res.setHeader("Allow", ["GET", "POST", "OPTIONS"]);

--- a/lib/rate-limit.js
+++ b/lib/rate-limit.js
@@ -2,8 +2,6 @@
 // Note: Each serverless instance maintains its own state
 // For distributed rate limiting, use Redis or Vercel Edge Config
 
-const rateLimitStore = new Map();
-
 /**
  * Creates a rate limiter with specified limits
  * @param {number} requests - Number of requests allowed
@@ -11,6 +9,10 @@ const rateLimitStore = new Map();
  * @returns {function} Rate limit checker function
  */
 export function createRateLimiter(requests, window) {
+  // Keep a dedicated in-memory store per limiter instance so endpoint
+  // quotas do not interfere with each other.
+  const rateLimitStore = new Map();
+
   return function checkRateLimit(identifier) {
     const now = Date.now();
     const key = identifier;

--- a/middleware.js
+++ b/middleware.js
@@ -3,6 +3,11 @@ export default async function middleware(request) {
   const host = request.headers.get("host") || "";
   const { pathname } = url;
 
+  // Local development should bypass middleware rewrites to avoid recursion in vercel dev.
+  if (host.startsWith("localhost:") || host.startsWith("127.0.0.1:")) {
+    return;
+  }
+
   // cancel.decide.fyi/api/mcp → /api/cancel-mcp
   if (host.startsWith("cancel.") && pathname === "/api/mcp") {
     const dest = new URL("/api/cancel-mcp", url.origin);
@@ -23,5 +28,5 @@ export default async function middleware(request) {
 
   // refund.decide.fyi routes pass through (api/mcp.js already handles refund)
   // All other routes pass through unchanged
-  return fetch(request);
+  return;
 }

--- a/package.json
+++ b/package.json
@@ -2,5 +2,8 @@
   "name": "decide",
   "version": "1.2.0",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "smoke": "node scripts/smoke-test.js"
+  }
 }

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -1,0 +1,221 @@
+import health from "../api/health.js";
+import refundRest from "../api/v1/refund/eligibility.js";
+import cancelRest from "../api/v1/cancel/penalty.js";
+import returnRest from "../api/v1/return/eligibility.js";
+import trialRest from "../api/v1/trial/terms.js";
+import refundMcp from "../api/mcp.js";
+import cancelMcp from "../api/cancel-mcp.js";
+import returnMcp from "../api/return-mcp.js";
+import trialMcp from "../api/trial-mcp.js";
+
+function createReq({
+  method = "GET",
+  headers = {},
+  body,
+  query = {},
+  url = "/",
+  remoteAddress = "127.0.0.1",
+} = {}) {
+  return {
+    method,
+    headers,
+    body,
+    query,
+    url,
+    socket: { remoteAddress },
+    [Symbol.asyncIterator]: async function* () {
+      if (typeof body === "string") {
+        yield Buffer.from(body);
+      }
+    },
+  };
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    setHeader(key, value) {
+      this.headers[key] = value;
+    },
+    end(chunk = "") {
+      this.body += String(chunk ?? "");
+    },
+  };
+}
+
+function parseJson(label, body) {
+  try {
+    return JSON.parse(body || "{}");
+  } catch (error) {
+    throw new Error(`${label}: response is not valid JSON (${error.message})`);
+  }
+}
+
+async function runCase(label, handler, reqOptions, assertFn) {
+  const req = createReq(reqOptions);
+  const res = createRes();
+  await handler(req, res);
+  const json = parseJson(label, res.body);
+  assertFn({ statusCode: res.statusCode, headers: res.headers, json });
+  console.log(`PASS ${label}`);
+}
+
+function expect(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function main() {
+  await runCase(
+    "health GET",
+    health,
+    { method: "GET" },
+    ({ statusCode, json }) => {
+      expect(statusCode === 200, "expected 200");
+      expect(json.ok === true, "expected ok=true");
+    }
+  );
+
+  await runCase(
+    "refund REST POST",
+    refundRest,
+    {
+      method: "POST",
+      headers: { "user-agent": "smoke-test" },
+      url: "/api/v1/refund/eligibility",
+      body: { vendor: "adobe", days_since_purchase: 5, region: "US", plan: "individual" },
+    },
+    ({ statusCode, json }) => {
+      expect(statusCode === 200, "expected 200");
+      expect(json.verdict === "ALLOWED", "expected ALLOWED");
+      expect(json.code === "WITHIN_WINDOW", "expected WITHIN_WINDOW");
+    }
+  );
+
+  await runCase(
+    "cancel REST POST",
+    cancelRest,
+    {
+      method: "POST",
+      headers: { "user-agent": "smoke-test" },
+      url: "/api/v1/cancel/penalty",
+      body: { vendor: "adobe", region: "US", plan: "individual" },
+    },
+    ({ statusCode, json }) => {
+      expect(statusCode === 200, "expected 200");
+      expect(typeof json.verdict === "string", "expected verdict");
+    }
+  );
+
+  await runCase(
+    "return REST POST",
+    returnRest,
+    {
+      method: "POST",
+      headers: { "user-agent": "smoke-test" },
+      url: "/api/v1/return/eligibility",
+      body: { vendor: "adobe", days_since_purchase: 5, region: "US", plan: "individual" },
+    },
+    ({ statusCode, json }) => {
+      expect(statusCode === 200, "expected 200");
+      expect(json.verdict === "RETURNABLE", "expected RETURNABLE");
+    }
+  );
+
+  await runCase(
+    "trial REST POST",
+    trialRest,
+    {
+      method: "POST",
+      headers: { "user-agent": "smoke-test" },
+      url: "/api/v1/trial/terms",
+      body: { vendor: "adobe", region: "US", plan: "individual" },
+    },
+    ({ statusCode, json }) => {
+      expect(statusCode === 200, "expected 200");
+      expect(typeof json.verdict === "string", "expected verdict");
+    }
+  );
+
+  await runCase(
+    "refund MCP initialize",
+    refundMcp,
+    {
+      method: "POST",
+      headers: { "user-agent": "smoke-test" },
+      body: { jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-11-25" } },
+    },
+    ({ statusCode, json }) => {
+      expect(statusCode === 200, "expected 200");
+      expect(json.result?.protocolVersion === "2025-11-25", "expected protocolVersion");
+    }
+  );
+
+  await runCase(
+    "cancel MCP tools/list",
+    cancelMcp,
+    {
+      method: "POST",
+      headers: { "user-agent": "smoke-test" },
+      body: { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+    },
+    ({ statusCode, json }) => {
+      expect(statusCode === 200, "expected 200");
+      expect(Array.isArray(json.result?.tools), "expected tools array");
+    }
+  );
+
+  await runCase(
+    "return MCP tools/call",
+    returnMcp,
+    {
+      method: "POST",
+      headers: { "user-agent": "smoke-test" },
+      body: {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "return_eligibility",
+          arguments: { vendor: "adobe", days_since_purchase: 5, region: "US", plan: "individual" },
+        },
+      },
+    },
+    ({ statusCode, json }) => {
+      expect(statusCode === 200, "expected 200");
+      expect(Array.isArray(json.result?.content), "expected content array");
+    }
+  );
+
+  await runCase(
+    "trial MCP tools/call",
+    trialMcp,
+    {
+      method: "POST",
+      headers: { "user-agent": "smoke-test" },
+      body: {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: {
+          name: "trial_terms",
+          arguments: { vendor: "adobe", region: "US", plan: "individual" },
+        },
+      },
+    },
+    ({ statusCode, json }) => {
+      expect(statusCode === 200, "expected 200");
+      expect(Array.isArray(json.result?.content), "expected content array");
+    }
+  );
+
+  console.log("Smoke test complete.");
+}
+
+main().catch((error) => {
+  console.error(`FAIL ${error.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What changed

- Fixed local dev middleware recursion by bypassing middleware rewrites on localhost/127.0.0.1.
- Isolated in-memory rate limit stores per limiter instance so endpoint quotas don't interfere.
- Improved `POST /api/decide` input handling: invalid JSON now returns `400` with a clear message.
- Added local smoke test runner at `scripts/smoke-test.js`.
- Added npm script: `npm run smoke`.
- Included `.gitignore` update from local Vercel linking flow.

## Why

- `vercel dev` was hitting middleware socket timeout/hang-up behavior locally.
- Shared global limiter state could cause cross-endpoint throttling.
- Invalid client JSON should be a client error, not an internal server error.
- Added one-command confidence check for local API/MCP health before pushing.

## Validation

- `npm run smoke` (all PASS)
- Local manual checks:
  - `GET /api/health` -> `200`
  - `POST /api/v1/refund/eligibility` -> `200` (`ALLOWED` for adobe sample)
  - `POST /api/mcp` initialize -> `200` with valid JSON-RPC result
