### PR TITLE
Fix doc inconsistencies and make MCP health check less brittle

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -24,13 +24,13 @@ Next 1-2 high-signal places to submit the refund notary.
 
 ## 📊 Priority
 
-**Do these in order:**
+**Current mode:**
 
-1. **modelcontextprotocol/servers** (highest signal)
-2. **smithery.ai** (good discovery)
-3. **Stop. Wait 7-10 days. Check logs.**
+1. **Stop. Wait 7-10 days. Check logs.**
+2. If external calls appear, iterate on docs/tooling before further distribution.
+3. If no calls appear, revisit one new high-signal channel.
 
-Do not spam more registries. Quality over quantity.
+Do not spam registries. Quality over quantity.
 
 ---
 

--- a/client/EXAMPLES.md
+++ b/client/EXAMPLES.md
@@ -199,7 +199,7 @@ Every response includes:
 ## Why Use This?
 
 - **Deterministic** - Same input always returns same output
-- **Stateless** - No accounts, no API keys, no rate limits
+- **Stateless** - No accounts, no API keys (rate limit: 100 req/min per IP)
 - **Fast** - ~50ms response time globally
 - **Authoritative** - Single source of truth for refund policies
 - **Agent-Ready** - MCP + REST, works in any agent framework

--- a/scripts/mcp-check.sh
+++ b/scripts/mcp-check.sh
@@ -23,22 +23,26 @@ assert_contains() {
   echo "PASS ${label}"
 }
 
+assert_jsonrpc_success() {
+  local label="$1"
+  local body="$2"
+  assert_contains "${label} jsonrpc" "$body" '"jsonrpc":"2.0"'
+  assert_contains "${label} content" "$body" '"content":[{"type":"text"'
+  assert_contains "${label} isError" "$body" '"isError":false'
+}
+
 echo "Checking MCP endpoints at ${BASE_URL}..."
 
 refund="$(post_json "/api/mcp" '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"refund_eligibility","arguments":{"vendor":"adobe","days_since_purchase":5,"region":"US","plan":"individual"}}}')"
-assert_contains "refund MCP" "$refund" '"isError":false'
-assert_contains "refund MCP verdict" "$refund" 'Refund Eligibility: ALLOWED'
+assert_jsonrpc_success "refund MCP" "$refund"
 
 cancel="$(post_json "/api/cancel-mcp" '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"cancellation_penalty","arguments":{"vendor":"adobe","region":"US","plan":"individual"}}}')"
-assert_contains "cancel MCP" "$cancel" '"isError":false'
-assert_contains "cancel MCP verdict" "$cancel" 'Cancellation Status: PENALTY'
+assert_jsonrpc_success "cancel MCP" "$cancel"
 
 returns="$(post_json "/api/return-mcp" '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"return_eligibility","arguments":{"vendor":"adobe","days_since_purchase":5,"region":"US","plan":"individual"}}}')"
-assert_contains "return MCP" "$returns" '"isError":false'
-assert_contains "return MCP verdict" "$returns" 'Return Eligibility: RETURNABLE'
+assert_jsonrpc_success "return MCP" "$returns"
 
 trial="$(post_json "/api/trial-mcp" '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"trial_terms","arguments":{"vendor":"adobe","region":"US","plan":"individual"}}}')"
-assert_contains "trial MCP" "$trial" '"isError":false'
-assert_contains "trial MCP verdict" "$trial" 'Trial Terms: TRIAL_AVAILABLE'
+assert_jsonrpc_success "trial MCP" "$trial"
 
 echo "All MCP checks passed."


### PR DESCRIPTION
Align docs with actual rate-limit behavior, resolve contradictory distribution guidance, and make mcp:check assert JSON-RPC success structure instead of vendor-specific verdict text.