### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ npm run workflow:test
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/decidefyi-decide).
+
 ## Zendesk Workflow Orchestrators
 
 Use workflow endpoints when you want one request to return:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/decidefyi-decide).