### PR TITLE
Align customer smoke with Decision Records

### DIFF
--- a/.github/workflows/inventory-freshness.yml
+++ b/.github/workflows/inventory-freshness.yml
@@ -14,6 +14,13 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install inventory tooling
+        run: |
+          if ! command -v rg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y ripgrep
+          fi
+
       - name: Check generated inventory docs are fresh
         run: |
           chmod +x ./scripts/generate-project-inventory.sh ./scripts/check-project-inventory.sh

--- a/FUNCTION_INTERCONNECTIONS.md
+++ b/FUNCTION_INTERCONNECTIONS.md
@@ -1,6 +1,6 @@
 # Function Inventory + Interconnection Map
 
-Generated: 2026-05-15 23:30:27 CEST
+Generated: 2026-05-30 13:37:44 CEST
 
 ## Scope
 
@@ -406,12 +406,12 @@ scripts/check-policies.js:891:function summarizePolicyStatusCounts(rows, statuse
 scripts/check-policies.js:904:function writePolicyStatusReports(rows, generatedAtUtc) {
 scripts/check-policies.js:966:function toIsoWeekKey(utcIso) {
 scripts/check-policies.js:979:function buildWeeklyTriageSnapshot(rows, generatedAtUtc) {
-scripts/customer-key-smoke.js:104:async function main() {
-scripts/customer-key-smoke.js:27:function parseArgs(argv) {
-scripts/customer-key-smoke.js:58:function normalizeBaseUrl(value) {
-scripts/customer-key-smoke.js:68:function redactKey(key) {
-scripts/customer-key-smoke.js:74:async function postJson(url, { key, question, timeoutMs }) {
-scripts/customer-key-smoke.js:8:function usage() {
+scripts/customer-key-smoke.js:114:async function main() {
+scripts/customer-key-smoke.js:17:function usage() {
+scripts/customer-key-smoke.js:36:function parseArgs(argv) {
+scripts/customer-key-smoke.js:67:function normalizeBaseUrl(value) {
+scripts/customer-key-smoke.js:77:function redactKey(key) {
+scripts/customer-key-smoke.js:83:async function postJson(url, { key, question, timeoutMs }) {
 scripts/generate-outbound-domain-inventory.mjs:103:function inferTags(host, ownSuffixes) {
 scripts/generate-outbound-domain-inventory.mjs:141:function riskTier(tags, contexts) {
 scripts/generate-outbound-domain-inventory.mjs:172:function isCriticalDomain(tags) {

--- a/FUNCTION_INTERCONNECTIONS.md
+++ b/FUNCTION_INTERCONNECTIONS.md
@@ -1,6 +1,6 @@
 # Function Inventory + Interconnection Map
 
-Generated: 2026-05-30 13:39:29 CEST
+Generated: 2026-05-30 14:10:40 CEST
 
 ## Scope
 
@@ -429,7 +429,7 @@ scripts/generate-outbound-domain-inventory.mjs:6:function parseArgs(argv) {
 scripts/generate-outbound-domain-inventory.mjs:72:function splitCombinedUrls(rawUrl) {
 scripts/generate-outbound-domain-inventory.mjs:79:function normalizeHost(hostname) {
 scripts/generate-outbound-domain-inventory.mjs:88:function inferContexts(filePath) {
-scripts/generate-project-inventory.sh:11:FUNC_PATTERN='export default|export async function|export function|function [A-Za-z0-9_]+\(|const [A-Za-z0-9_]+\s*=\s*\([^)]*\)\s*=>|const [A-Za-z0-9_]+\s*=\s*async\s*\([^)]*\)\s*=>'
+scripts/generate-project-inventory.sh:16:FUNC_PATTERN='export default|export async function|export function|function [A-Za-z0-9_]+\(|const [A-Za-z0-9_]+\s*=\s*\([^)]*\)\s*=>|const [A-Za-z0-9_]+\s*=\s*async\s*\([^)]*\)\s*=>'
 scripts/lib/policy-feed-reliability.js:100:export function mergePolicyAlertFeed({
 scripts/lib/policy-feed-reliability.js:13:function normalizeByPolicy(byPolicyValue) {
 scripts/lib/policy-feed-reliability.js:23:function buildByPolicySignature(byPolicy) {

--- a/FUNCTION_INTERCONNECTIONS.md
+++ b/FUNCTION_INTERCONNECTIONS.md
@@ -1,6 +1,6 @@
 # Function Inventory + Interconnection Map
 
-Generated: 2026-05-30 13:37:44 CEST
+Generated: 2026-05-30 13:39:29 CEST
 
 ## Scope
 

--- a/OUTBOUND_DOMAIN_INVENTORY.md
+++ b/OUTBOUND_DOMAIN_INVENTORY.md
@@ -1,6 +1,6 @@
 # Outbound Domain Inventory (Exhaustive)
 
-Generated: 2026-05-15T21:30:27.181Z
+Generated: 2026-05-30T11:37:44.388Z
 
 Repository: `decide`
 
@@ -10,13 +10,13 @@ Lockfiles and binary image assets are excluded to reduce noise.
 
 ## 1) Snapshot
 
-- Total URL occurrences scanned: **2256**
-- Valid URL occurrences parsed: **2250**
-- Invalid/truncated URL occurrences: **6**
-- Unique hosts: **199**
+- Total URL occurrences scanned: **2259**
+- Valid URL occurrences parsed: **2252**
+- Invalid/truncated URL occurrences: **7**
+- Unique hosts: **201**
 - Critical integration hosts: **13**
 - First-party hosts: **8**
-- Third-party hosts: **191**
+- Third-party hosts: **193**
 
 ### Risk-tier distribution
 
@@ -25,7 +25,7 @@ Lockfiles and binary image assets are excluded to reduce noise.
 - T1-observability: 1
 - T1-platform-control: 5
 - T2-first-party-surface: 6
-- T3-content-static: 180
+- T3-content-static: 182
 
 ### Top hosts by URL occurrences
 
@@ -58,19 +58,19 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 
 | Host | URL occurrences | Files | Context(s) | Risk tier | Tag(s) | Example references |
 | --- | ---: | ---: | --- | --- | --- | --- |
-| github.com | 80 | 10 | config_or_data, data_source, frontend, other | T1-platform-control (Platform/control-plane dependency.) | github, third_party | public/index.html:340, public/rules/trial-policy-sources.json:29, rules/policy-alert-feed.json:117 |
+| github.com | 80 | 10 | config_or_data, data_source, frontend, other | T1-platform-control (Platform/control-plane dependency.) | github, third_party | public/index.html:344, public/rules/trial-policy-sources.json:29, rules/policy-alert-feed.json:117 |
 | *.clerk.com | 3 | 1 | config_or_data | T1-auth-billing (Auth, payment, or customer-contact dependency.) | clerk, third_party | vercel.json:28, vercel.json:28, vercel.json:28 |
 | *.clerk.dev | 3 | 1 | config_or_data | T1-auth-billing (Auth, payment, or customer-contact dependency.) | clerk, third_party | vercel.json:28, vercel.json:28, vercel.json:28 |
 | api.axiom.co | 3 | 2 | other | T1-observability (Monitoring/logging dependency.) | axiom, third_party | lib/log.js:9, lib/metrics-axiom.js:65, lib/metrics-axiom.js:70 |
 | challenges.cloudflare.com | 2 | 1 | config_or_data | T1-platform-control (Platform/control-plane dependency.) | cloudflare, third_party | vercel.json:28, vercel.json:28 |
-| chrome.browserless.io | 2 | 2 | docs_content, other | T0-critical-runtime (Direct runtime dependency for decisioning/fetch/storage.) | browserless, third_party | README.md:396, api/policy-fetch-hook.js:168 |
+| chrome.browserless.io | 2 | 2 | docs_content, other | T0-critical-runtime (Direct runtime dependency for decisioning/fetch/storage.) | browserless, third_party | README.md:399, api/policy-fetch-hook.js:168 |
 | generativelanguage.googleapis.com | 2 | 2 | config_or_data, other | T0-critical-runtime (Direct runtime dependency for decisioning/fetch/storage.) | gemini, third_party | api/decide.js:300, vercel.json:28 |
 | r.jina.ai | 2 | 2 | other | T0-critical-runtime (Direct runtime dependency for decisioning/fetch/storage.) | jina_mirror, third_party | api/policy-fetch-hook.js:95, scripts/check-policies.js:3082 |
 | raw.githubusercontent.com | 2 | 1 | docs_content | T1-platform-control (Platform/control-plane dependency.) | github, third_party | client/EXAMPLES.md:84, client/EXAMPLES.md:102 |
 | *.vercel.app | 1 | 1 | config_or_data | T1-platform-control (Platform/control-plane dependency.) | third_party, vercel | vercel.json:28 |
 | accounts.decide.fyi | 1 | 1 | config_or_data | T1-auth-billing (Auth, payment, or customer-contact dependency.) | clerk, first_party | vercel.json:28 |
 | clerk.decide.fyi | 1 | 1 | config_or_data | T1-auth-billing (Auth, payment, or customer-contact dependency.) | clerk, first_party | vercel.json:28 |
-| decide-1.vercel.app | 1 | 1 | docs_content | T1-platform-control (Platform/control-plane dependency.) | third_party, vercel | README.md:400 |
+| decide-1.vercel.app | 1 | 1 | docs_content | T1-platform-control (Platform/control-plane dependency.) | third_party, vercel | README.md:403 |
 
 ## 3) Full Host Inventory (Alphabetical, Exhaustive)
 
@@ -79,6 +79,7 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | *.clerk.com | 3 | 1 | config_or_data | T1-auth-billing | clerk, third_party | vercel.json:28, vercel.json:28, vercel.json:28 |
 | *.clerk.dev | 3 | 1 | config_or_data | T1-auth-billing | clerk, third_party | vercel.json:28, vercel.json:28, vercel.json:28 |
 | *.vercel.app | 1 | 1 | config_or_data | T1-platform-control | third_party, vercel | vercel.json:28 |
+| 127.0.0.1 | 1 | 1 | other | T3-content-static | third_party | Dockerfile:20 |
 | 1password.com | 9 | 8 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:5, rules/cancel-policy-sources.json:10, rules/policy-sources.json:10 |
 | accounts.decide.fyi | 1 | 1 | config_or_data | T1-auth-billing | clerk, first_party | vercel.json:28 |
 | api.axiom.co | 3 | 2 | other | T1-observability | axiom, third_party | lib/log.js:9, lib/metrics-axiom.js:65, lib/metrics-axiom.js:70 |
@@ -87,12 +88,12 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | cancel.decide.fyi | 11 | 6 | config_or_data, docs_content, frontend, other | T2-first-party-surface | first_party | README.md:22, README.md:36, README.md:52 |
 | cdn.jsdelivr.net | 1 | 1 | config_or_data | T3-content-static | third_party | vercel.json:28 |
 | challenges.cloudflare.com | 2 | 1 | config_or_data | T1-platform-control | cloudflare, third_party | vercel.json:28, vercel.json:28 |
-| chrome.browserless.io | 2 | 2 | docs_content, other | T0-critical-runtime | browserless, third_party | README.md:396, api/policy-fetch-hook.js:168 |
+| chrome.browserless.io | 2 | 2 | docs_content, other | T0-critical-runtime | browserless, third_party | README.md:399, api/policy-fetch-hook.js:168 |
 | claude.ai | 5 | 5 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:17, rules/trial-policy-confirmed-baseline.json:122, rules/trial-policy-coverage-state.json:315 |
 | clerk.decide.fyi | 1 | 1 | config_or_data | T1-auth-billing | clerk, first_party | vercel.json:28 |
 | cursor.com | 1 | 1 | docs_content | T3-content-static | third_party | README.md:13 |
 | customercenter.wsj.com | 15 | 12 | config_or_data | T3-content-static | third_party | rules/cancel-policy-confirmed-baseline.json:591, rules/cancel-policy-coverage-state.json:1863, rules/cancel-policy-semantic-state.json:1333 |
-| decide-1.vercel.app | 1 | 1 | docs_content | T1-platform-control | third_party, vercel | README.md:400 |
+| decide-1.vercel.app | 1 | 1 | docs_content | T1-platform-control | third_party, vercel | README.md:403 |
 | decide.fyi | 1 | 1 | other | T2-first-party-surface | first_party | api/track.js:115 |
 | discord.com | 25 | 14 | config_or_data, other | T3-content-static | third_party | rules/cancel-policy-confirmed-baseline.json:150, rules/cancel-policy-semantic-state.json:309, rules/cancel-policy-sources.json:130 |
 | docs.github.com | 15 | 15 | config_or_data, data_source | T3-content-static | third_party | public/rules/cancel-policy-sources.json:29, public/rules/policy-sources.json:102, public/rules/return-policy-sources.json:29 |
@@ -101,12 +102,12 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | en-americas-support.nintendo.com | 5 | 5 | config_or_data, data_source | T3-content-static | third_party | public/rules/cancel-policy-sources.json:44, rules/cancel-policy-confirmed-baseline.json:374, rules/cancel-policy-coverage-state.json:1011 |
 | en.help.roblox.com | 10 | 10 | config_or_data | T3-content-static | third_party | rules/cancel-policy-confirmed-baseline.json:451, rules/cancel-policy-coverage-state.json:1771, rules/cancel-policy-semantic-state.json:1261 |
 | evernote.com | 12 | 7 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:25, rules/cancel-policy-sources.json:177, rules/cancel-policy-sources.json:178 |
-| example.com | 8 | 2 | docs_content, other | T3-content-static | third_party | README.md:383, scripts/test-check-policies.js:379, scripts/test-check-policies.js:380 |
+| example.com | 8 | 2 | docs_content, other | T3-content-static | third_party | README.md:386, scripts/test-check-policies.js:379, scripts/test-check-policies.js:380 |
 | fastmcp.me | 4 | 1 | docs_content | T3-content-static | third_party | README.md:13, README.md:13, README.md:13 |
 | fonts.googleapis.com | 1 | 1 | config_or_data | T3-content-static | google_fonts, third_party | vercel.json:28 |
 | fonts.gstatic.com | 1 | 1 | config_or_data | T3-content-static | google_fonts, third_party | vercel.json:28 |
 | generativelanguage.googleapis.com | 2 | 2 | config_or_data, other | T0-critical-runtime | gemini, third_party | api/decide.js:300, vercel.json:28 |
-| github.com | 80 | 10 | config_or_data, data_source, frontend, other | T1-platform-control | github, third_party | public/index.html:340, public/rules/trial-policy-sources.json:29, rules/policy-alert-feed.json:117 |
+| github.com | 80 | 10 | config_or_data, data_source, frontend, other | T1-platform-control | github, third_party | public/index.html:344, public/rules/trial-policy-sources.json:29, rules/policy-alert-feed.json:117 |
 | glama.ai | 1 | 1 | config_or_data | T3-content-static | third_party | glama.json:2 |
 | hellofreshusa.zendesk.com | 9 | 9 | config_or_data, data_source | T3-content-static | third_party | public/rules/policy-sources.json:118, public/rules/return-policy-sources.json:33, rules/policy-confirmed-baseline.json:276 |
 | help.audible.com | 9 | 8 | config_or_data, data_source | T3-content-static | third_party | public/rules/cancel-policy-sources.json:11, rules/cancel-policy-confirmed-baseline.json:73, rules/cancel-policy-coverage-state.json:186 |
@@ -144,7 +145,7 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | openai.com | 9 | 8 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:16, rules/cancel-policy-sources.json:96, rules/policy-sources.json:91 |
 | play.google.com | 2 | 2 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:30, rules/trial-policy-sources.json:210 |
 | premium.linkedin.com | 5 | 5 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:38, rules/trial-policy-confirmed-baseline.json:339, rules/trial-policy-coverage-state.json:881 |
-| preview.example.com | 1 | 1 | docs_content | T3-content-static | third_party | docs/FIRST_CUSTOMER_RUNBOOK.md:35 |
+| preview.example.com | 1 | 1 | docs_content | T3-content-static | third_party | docs/FIRST_CUSTOMER_RUNBOOK.md:39 |
 | proton.me | 24 | 16 | config_or_data | T3-content-static | third_party | rules/cancel-policy-confirmed-baseline.json:430, rules/cancel-policy-coverage-state.json:1120, rules/cancel-policy-semantic-state.json:779 |
 | r.jina.ai | 2 | 2 | other | T0-critical-runtime | jina_mirror, third_party | api/policy-fetch-hook.js:95, scripts/check-policies.js:3082 |
 | raw.githubusercontent.com | 2 | 1 | docs_content | T1-platform-control | github, third_party | client/EXAMPLES.md:84, client/EXAMPLES.md:102 |
@@ -208,7 +209,7 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | www.coursera.support | 15 | 15 | config_or_data, data_source | T3-content-static | third_party | public/rules/cancel-policy-sources.json:18, public/rules/policy-sources.json:58, public/rules/return-policy-sources.json:18 |
 | www.crunchyroll.com | 6 | 6 | config_or_data, data_source, other | T3-content-static | third_party | public/rules/trial-policy-sources.json:19, rules/policy-events.ndjson:21, rules/trial-policy-confirmed-baseline.json:136 |
 | www.dashlane.com | 6 | 6 | config_or_data | T3-content-static | third_party | rules/policy-sources.json:461, rules/return-policy-sources.json:461, rules/trial-policy-confirmed-baseline.json:143 |
-| www.decide.fyi | 7 | 4 | docs_content, other | T2-first-party-surface | first_party | README.md:409, docs/FIRST_CUSTOMER_RUNBOOK.md:17, docs/FIRST_CUSTOMER_RUNBOOK.md:45 |
+| www.decide.fyi | 7 | 4 | docs_content, other | T2-first-party-surface | first_party | README.md:412, docs/FIRST_CUSTOMER_RUNBOOK.md:17, docs/FIRST_CUSTOMER_RUNBOOK.md:49 |
 | www.deezer.com | 17 | 17 | config_or_data, data_source | T3-content-static | third_party | public/rules/cancel-policy-sources.json:20, public/rules/policy-sources.json:66, public/rules/return-policy-sources.json:20 |
 | www.discoveryplus.com | 11 | 10 | config_or_data | T3-content-static | third_party | rules/cancel-policy-sources.json:658, rules/cancel-policy-sources.json:659, rules/policy-confirmed-baseline.json:164 |
 | www.disneyplus.com | 18 | 12 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:21, rules/cancel-policy-sources.json:146, rules/cancel-policy-sources.json:170 |
@@ -266,6 +267,7 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | www.twitch.tv | 15 | 14 | config_or_data, data_source | T3-content-static | third_party | public/rules/policy-sources.json:238, public/rules/return-policy-sources.json:63, public/rules/trial-policy-sources.json:63 |
 | www.uber.com | 20 | 12 | config_or_data | T3-content-static | third_party | rules/cancel-policy-confirmed-baseline.json:577, rules/cancel-policy-semantic-state.json:1020, rules/cancel-policy-sources.json:463 |
 | www.ubisoft.com | 4 | 4 | config_or_data, other | T3-content-static | third_party | rules/cancel-policy-confirmed-baseline.json:584, rules/cancel-policy-semantic-state.json:1244, rules/cancel-policy-sources.json:565 |
+| www.w3.org | 1 | 1 | frontend | T3-content-static | third_party | public/index.html:9 |
 | www.walmart.com | 16 | 16 | config_or_data, data_source | T3-content-static | third_party | public/rules/cancel-policy-sources.json:64, public/rules/policy-sources.json:242, public/rules/return-policy-sources.json:64 |
 | www.washingtonpost.com | 6 | 6 | config_or_data | T3-content-static | third_party | rules/policy-sources.json:547, rules/return-policy-sources.json:547, rules/trial-policy-confirmed-baseline.json:654 |
 | www.weightwatchers.com | 18 | 17 | config_or_data, other | T3-content-static | third_party | rules/cancel-policy-confirmed-baseline.json:612, rules/cancel-policy-coverage-state.json:1676, rules/cancel-policy-semantic-state.json:1210 |
@@ -273,7 +275,7 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | www.wsj.com | 4 | 4 | config_or_data | T3-content-static | third_party | rules/trial-policy-confirmed-baseline.json:640, rules/trial-policy-coverage-state.json:1958, rules/trial-policy-semantic-state.json:1425 |
 | www.xbox.com | 5 | 5 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:66, rules/trial-policy-confirmed-baseline.json:682, rules/trial-policy-coverage-state.json:1544 |
 | www.youtube.com | 10 | 9 | config_or_data, data_source, other | T3-content-static | third_party | public/rules/trial-policy-sources.json:67, rules/cancel-policy-sources.json:490, rules/policy-events.ndjson:32 |
-| x.com | 3 | 2 | config_or_data, docs_content | T3-content-static | third_party | README.md:404, README.md:414, rules/trial-policy-sources.json:544 |
+| x.com | 3 | 2 | config_or_data, docs_content | T3-content-static | third_party | README.md:407, README.md:417, rules/trial-policy-sources.json:544 |
 | zoom.us | 5 | 5 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:68, rules/trial-policy-confirmed-baseline.json:703, rules/trial-policy-coverage-state.json:2209 |
 
 ## 4) Generation Method

--- a/OUTBOUND_DOMAIN_INVENTORY.md
+++ b/OUTBOUND_DOMAIN_INVENTORY.md
@@ -1,6 +1,6 @@
 # Outbound Domain Inventory (Exhaustive)
 
-Generated: 2026-05-30T11:39:30.001Z
+Generated: 2026-05-30T12:10:40.374Z
 
 Repository: `decide`
 

--- a/OUTBOUND_DOMAIN_INVENTORY.md
+++ b/OUTBOUND_DOMAIN_INVENTORY.md
@@ -1,6 +1,6 @@
 # Outbound Domain Inventory (Exhaustive)
 
-Generated: 2026-05-30T11:37:44.388Z
+Generated: 2026-05-30T11:39:30.001Z
 
 Repository: `decide`
 
@@ -10,9 +10,9 @@ Lockfiles and binary image assets are excluded to reduce noise.
 
 ## 1) Snapshot
 
-- Total URL occurrences scanned: **2259**
+- Total URL occurrences scanned: **2258**
 - Valid URL occurrences parsed: **2252**
-- Invalid/truncated URL occurrences: **7**
+- Invalid/truncated URL occurrences: **6**
 - Unique hosts: **201**
 - Critical integration hosts: **13**
 - First-party hosts: **8**
@@ -63,14 +63,14 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | *.clerk.dev | 3 | 1 | config_or_data | T1-auth-billing (Auth, payment, or customer-contact dependency.) | clerk, third_party | vercel.json:28, vercel.json:28, vercel.json:28 |
 | api.axiom.co | 3 | 2 | other | T1-observability (Monitoring/logging dependency.) | axiom, third_party | lib/log.js:9, lib/metrics-axiom.js:65, lib/metrics-axiom.js:70 |
 | challenges.cloudflare.com | 2 | 1 | config_or_data | T1-platform-control (Platform/control-plane dependency.) | cloudflare, third_party | vercel.json:28, vercel.json:28 |
-| chrome.browserless.io | 2 | 2 | docs_content, other | T0-critical-runtime (Direct runtime dependency for decisioning/fetch/storage.) | browserless, third_party | README.md:399, api/policy-fetch-hook.js:168 |
+| chrome.browserless.io | 2 | 2 | docs_content, other | T0-critical-runtime (Direct runtime dependency for decisioning/fetch/storage.) | browserless, third_party | README.md:396, api/policy-fetch-hook.js:168 |
 | generativelanguage.googleapis.com | 2 | 2 | config_or_data, other | T0-critical-runtime (Direct runtime dependency for decisioning/fetch/storage.) | gemini, third_party | api/decide.js:300, vercel.json:28 |
 | r.jina.ai | 2 | 2 | other | T0-critical-runtime (Direct runtime dependency for decisioning/fetch/storage.) | jina_mirror, third_party | api/policy-fetch-hook.js:95, scripts/check-policies.js:3082 |
 | raw.githubusercontent.com | 2 | 1 | docs_content | T1-platform-control (Platform/control-plane dependency.) | github, third_party | client/EXAMPLES.md:84, client/EXAMPLES.md:102 |
 | *.vercel.app | 1 | 1 | config_or_data | T1-platform-control (Platform/control-plane dependency.) | third_party, vercel | vercel.json:28 |
 | accounts.decide.fyi | 1 | 1 | config_or_data | T1-auth-billing (Auth, payment, or customer-contact dependency.) | clerk, first_party | vercel.json:28 |
 | clerk.decide.fyi | 1 | 1 | config_or_data | T1-auth-billing (Auth, payment, or customer-contact dependency.) | clerk, first_party | vercel.json:28 |
-| decide-1.vercel.app | 1 | 1 | docs_content | T1-platform-control (Platform/control-plane dependency.) | third_party, vercel | README.md:403 |
+| decide-1.vercel.app | 1 | 1 | docs_content | T1-platform-control (Platform/control-plane dependency.) | third_party, vercel | README.md:400 |
 
 ## 3) Full Host Inventory (Alphabetical, Exhaustive)
 
@@ -88,12 +88,12 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | cancel.decide.fyi | 11 | 6 | config_or_data, docs_content, frontend, other | T2-first-party-surface | first_party | README.md:22, README.md:36, README.md:52 |
 | cdn.jsdelivr.net | 1 | 1 | config_or_data | T3-content-static | third_party | vercel.json:28 |
 | challenges.cloudflare.com | 2 | 1 | config_or_data | T1-platform-control | cloudflare, third_party | vercel.json:28, vercel.json:28 |
-| chrome.browserless.io | 2 | 2 | docs_content, other | T0-critical-runtime | browserless, third_party | README.md:399, api/policy-fetch-hook.js:168 |
+| chrome.browserless.io | 2 | 2 | docs_content, other | T0-critical-runtime | browserless, third_party | README.md:396, api/policy-fetch-hook.js:168 |
 | claude.ai | 5 | 5 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:17, rules/trial-policy-confirmed-baseline.json:122, rules/trial-policy-coverage-state.json:315 |
 | clerk.decide.fyi | 1 | 1 | config_or_data | T1-auth-billing | clerk, first_party | vercel.json:28 |
 | cursor.com | 1 | 1 | docs_content | T3-content-static | third_party | README.md:13 |
 | customercenter.wsj.com | 15 | 12 | config_or_data | T3-content-static | third_party | rules/cancel-policy-confirmed-baseline.json:591, rules/cancel-policy-coverage-state.json:1863, rules/cancel-policy-semantic-state.json:1333 |
-| decide-1.vercel.app | 1 | 1 | docs_content | T1-platform-control | third_party, vercel | README.md:403 |
+| decide-1.vercel.app | 1 | 1 | docs_content | T1-platform-control | third_party, vercel | README.md:400 |
 | decide.fyi | 1 | 1 | other | T2-first-party-surface | first_party | api/track.js:115 |
 | discord.com | 25 | 14 | config_or_data, other | T3-content-static | third_party | rules/cancel-policy-confirmed-baseline.json:150, rules/cancel-policy-semantic-state.json:309, rules/cancel-policy-sources.json:130 |
 | docs.github.com | 15 | 15 | config_or_data, data_source | T3-content-static | third_party | public/rules/cancel-policy-sources.json:29, public/rules/policy-sources.json:102, public/rules/return-policy-sources.json:29 |
@@ -102,7 +102,7 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | en-americas-support.nintendo.com | 5 | 5 | config_or_data, data_source | T3-content-static | third_party | public/rules/cancel-policy-sources.json:44, rules/cancel-policy-confirmed-baseline.json:374, rules/cancel-policy-coverage-state.json:1011 |
 | en.help.roblox.com | 10 | 10 | config_or_data | T3-content-static | third_party | rules/cancel-policy-confirmed-baseline.json:451, rules/cancel-policy-coverage-state.json:1771, rules/cancel-policy-semantic-state.json:1261 |
 | evernote.com | 12 | 7 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:25, rules/cancel-policy-sources.json:177, rules/cancel-policy-sources.json:178 |
-| example.com | 8 | 2 | docs_content, other | T3-content-static | third_party | README.md:386, scripts/test-check-policies.js:379, scripts/test-check-policies.js:380 |
+| example.com | 8 | 2 | docs_content, other | T3-content-static | third_party | README.md:383, scripts/test-check-policies.js:379, scripts/test-check-policies.js:380 |
 | fastmcp.me | 4 | 1 | docs_content | T3-content-static | third_party | README.md:13, README.md:13, README.md:13 |
 | fonts.googleapis.com | 1 | 1 | config_or_data | T3-content-static | google_fonts, third_party | vercel.json:28 |
 | fonts.gstatic.com | 1 | 1 | config_or_data | T3-content-static | google_fonts, third_party | vercel.json:28 |
@@ -209,7 +209,7 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | www.coursera.support | 15 | 15 | config_or_data, data_source | T3-content-static | third_party | public/rules/cancel-policy-sources.json:18, public/rules/policy-sources.json:58, public/rules/return-policy-sources.json:18 |
 | www.crunchyroll.com | 6 | 6 | config_or_data, data_source, other | T3-content-static | third_party | public/rules/trial-policy-sources.json:19, rules/policy-events.ndjson:21, rules/trial-policy-confirmed-baseline.json:136 |
 | www.dashlane.com | 6 | 6 | config_or_data | T3-content-static | third_party | rules/policy-sources.json:461, rules/return-policy-sources.json:461, rules/trial-policy-confirmed-baseline.json:143 |
-| www.decide.fyi | 7 | 4 | docs_content, other | T2-first-party-surface | first_party | README.md:412, docs/FIRST_CUSTOMER_RUNBOOK.md:17, docs/FIRST_CUSTOMER_RUNBOOK.md:49 |
+| www.decide.fyi | 7 | 4 | docs_content, other | T2-first-party-surface | first_party | README.md:409, docs/FIRST_CUSTOMER_RUNBOOK.md:17, docs/FIRST_CUSTOMER_RUNBOOK.md:49 |
 | www.deezer.com | 17 | 17 | config_or_data, data_source | T3-content-static | third_party | public/rules/cancel-policy-sources.json:20, public/rules/policy-sources.json:66, public/rules/return-policy-sources.json:20 |
 | www.discoveryplus.com | 11 | 10 | config_or_data | T3-content-static | third_party | rules/cancel-policy-sources.json:658, rules/cancel-policy-sources.json:659, rules/policy-confirmed-baseline.json:164 |
 | www.disneyplus.com | 18 | 12 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:21, rules/cancel-policy-sources.json:146, rules/cancel-policy-sources.json:170 |
@@ -275,7 +275,7 @@ These are domains tagged as runtime/ops critical (`vercel`, `github`, `stripe`, 
 | www.wsj.com | 4 | 4 | config_or_data | T3-content-static | third_party | rules/trial-policy-confirmed-baseline.json:640, rules/trial-policy-coverage-state.json:1958, rules/trial-policy-semantic-state.json:1425 |
 | www.xbox.com | 5 | 5 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:66, rules/trial-policy-confirmed-baseline.json:682, rules/trial-policy-coverage-state.json:1544 |
 | www.youtube.com | 10 | 9 | config_or_data, data_source, other | T3-content-static | third_party | public/rules/trial-policy-sources.json:67, rules/cancel-policy-sources.json:490, rules/policy-events.ndjson:32 |
-| x.com | 3 | 2 | config_or_data, docs_content | T3-content-static | third_party | README.md:407, README.md:417, rules/trial-policy-sources.json:544 |
+| x.com | 3 | 2 | config_or_data, docs_content | T3-content-static | third_party | README.md:404, README.md:414, rules/trial-policy-sources.json:544 |
 | zoom.us | 5 | 5 | config_or_data, data_source | T3-content-static | third_party | public/rules/trial-policy-sources.json:68, rules/trial-policy-confirmed-baseline.json:703, rules/trial-policy-coverage-state.json:2209 |
 
 ## 4) Generation Method

--- a/OUTBOUND_URL_PARSE_ISSUES.md
+++ b/OUTBOUND_URL_PARSE_ISSUES.md
@@ -1,22 +1,24 @@
 # Outbound URL Parse Issues
 
-Generated: 2026-05-15T21:30:27.181Z
+Generated: 2026-05-30T11:37:44.388Z
 
-- Raw URL-matched lines scanned: **2256**
-- Parse/normalization issues: **6**
+- Raw URL-matched lines scanned: **2259**
+- Parse/normalization issues: **7**
 
 ## Reason Summary
 
 - url_parse_error: 6
+- invalid_host: 1
 
 ## Issue List
 
 | File | Line | Reason | URL fragment |
 | --- | ---: | --- | --- |
-| README.md | 408 | url_parse_error | https://decide.fyi](https://decide.fyi |
-| README.md | 410 | url_parse_error | https://refund.decide.fyi](https://refund.decide.fyi |
-| README.md | 411 | url_parse_error | https://cancel.decide.fyi](https://cancel.decide.fyi |
-| README.md | 412 | url_parse_error | https://return.decide.fyi](https://return.decide.fyi |
-| README.md | 413 | url_parse_error | https://trial.decide.fyi](https://trial.decide.fyi |
-| README.md | 415 | url_parse_error | https://modelcontextprotocol.io](https://modelcontextprotocol.io |
+| README.md | 411 | url_parse_error | https://decide.fyi](https://decide.fyi |
+| README.md | 413 | url_parse_error | https://refund.decide.fyi](https://refund.decide.fyi |
+| README.md | 414 | url_parse_error | https://cancel.decide.fyi](https://cancel.decide.fyi |
+| README.md | 415 | url_parse_error | https://return.decide.fyi](https://return.decide.fyi |
+| README.md | 416 | url_parse_error | https://trial.decide.fyi](https://trial.decide.fyi |
+| README.md | 418 | url_parse_error | https://modelcontextprotocol.io](https://modelcontextprotocol.io |
+| scripts/mcp-check-local.sh | 6 | invalid_host | http://$ |
 

--- a/OUTBOUND_URL_PARSE_ISSUES.md
+++ b/OUTBOUND_URL_PARSE_ISSUES.md
@@ -1,6 +1,6 @@
 # Outbound URL Parse Issues
 
-Generated: 2026-05-30T11:39:30.001Z
+Generated: 2026-05-30T12:10:40.374Z
 
 - Raw URL-matched lines scanned: **2258**
 - Parse/normalization issues: **6**

--- a/OUTBOUND_URL_PARSE_ISSUES.md
+++ b/OUTBOUND_URL_PARSE_ISSUES.md
@@ -1,24 +1,22 @@
 # Outbound URL Parse Issues
 
-Generated: 2026-05-30T11:37:44.388Z
+Generated: 2026-05-30T11:39:30.001Z
 
-- Raw URL-matched lines scanned: **2259**
-- Parse/normalization issues: **7**
+- Raw URL-matched lines scanned: **2258**
+- Parse/normalization issues: **6**
 
 ## Reason Summary
 
 - url_parse_error: 6
-- invalid_host: 1
 
 ## Issue List
 
 | File | Line | Reason | URL fragment |
 | --- | ---: | --- | --- |
-| README.md | 411 | url_parse_error | https://decide.fyi](https://decide.fyi |
-| README.md | 413 | url_parse_error | https://refund.decide.fyi](https://refund.decide.fyi |
-| README.md | 414 | url_parse_error | https://cancel.decide.fyi](https://cancel.decide.fyi |
-| README.md | 415 | url_parse_error | https://return.decide.fyi](https://return.decide.fyi |
-| README.md | 416 | url_parse_error | https://trial.decide.fyi](https://trial.decide.fyi |
-| README.md | 418 | url_parse_error | https://modelcontextprotocol.io](https://modelcontextprotocol.io |
-| scripts/mcp-check-local.sh | 6 | invalid_host | http://$ |
+| README.md | 408 | url_parse_error | https://decide.fyi](https://decide.fyi |
+| README.md | 410 | url_parse_error | https://refund.decide.fyi](https://refund.decide.fyi |
+| README.md | 411 | url_parse_error | https://cancel.decide.fyi](https://cancel.decide.fyi |
+| README.md | 412 | url_parse_error | https://return.decide.fyi](https://return.decide.fyi |
+| README.md | 413 | url_parse_error | https://trial.decide.fyi](https://trial.decide.fyi |
+| README.md | 415 | url_parse_error | https://modelcontextprotocol.io](https://modelcontextprotocol.io |
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ DECIDE_SMOKE_API_KEY='<customer-key>' npm run smoke:customer-key
 
 Use workflow endpoints when you want one request to return:
 
-- decision classification (`yes | no | tie`) from `/api/decide`
+- decision classification (`yes | no`) from `/api/decide`
 - policy result from the relevant notary endpoint
 - recommended Zendesk action + tags + private note with `request_id`
 

--- a/docs/FIRST_CUSTOMER_RUNBOOK.md
+++ b/docs/FIRST_CUSTOMER_RUNBOOK.md
@@ -17,9 +17,13 @@ PASS customer key smoke
 endpoint=https://www.decide.fyi/api/decide
 status=200
 decision=yes
+decision_record_version=decision_record_v1
+decision_id=...
 request_id=...
 policy_version=...
 source_hash=...
+record_hash=...
+verify_url=...
 latency_ms=...
 ```
 
@@ -45,14 +49,17 @@ export DECIDE_API_KEY='<customer-key>'
 curl -sS -X POST https://www.decide.fyi/api/decide \
   -H "Authorization: Bearer $DECIDE_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"mode":"single","question":"Should this support workflow use one deterministic API verdict for routing?"}'
+  -d '{"mode":"single","response_view":"full","question":"Should this support workflow use one deterministic API verdict for routing?"}'
 ```
 
 The response should include:
 
-- `c`: `yes`, `no`, or `tie`
-- `v`: stable verdict string
+- `decision_record_version`: `decision_record_v1`
+- `decision_id`: stable Decision Record handle
 - `request_id`: support/debug handle
+- `verdict` / `c`: `yes` or `no` for a successful single-decision smoke
+- `v`: stable verdict string
+- `record_hash` and `verify_url`: public verification fields
 - `policy_version` and `source_hash`: replay/audit fields
 
 ## Free policy proof curl
@@ -70,7 +77,7 @@ curl -sS -X POST https://refund.decide.fyi/api/v1/refund/eligibility \
 - `401`: key not provisioned, copied incorrectly, or pointed at the wrong environment.
 - `429`: customer is hitting rate limit or the smoke was repeated too quickly.
 - `c="unclear"` with `v="try again"`: auth/transport worked, but model/provider path is degraded; check runtime logs and model fallback attempts.
-- Missing `request_id`, `policy_version`, or `source_hash`: response contract regression; do not hand off until fixed.
+- Missing `decision_record_version`, `decision_id`, `request_id`, `policy_version`, `source_hash`, `record_hash`, or `verify_url`: response contract regression; do not hand off until fixed.
 
 ## Handoff checklist
 

--- a/scripts/check-project-inventory.sh
+++ b/scripts/check-project-inventory.sh
@@ -57,6 +57,7 @@ if [[ "$changed" -ne 0 ]]; then
   echo
   echo "Inventory docs are stale. Regenerated files differ from committed versions."
   echo "Run: ./scripts/generate-project-inventory.sh"
+  git --no-pager diff -- "${FILES[@]}" || true
   exit 1
 fi
 

--- a/scripts/customer-key-smoke.js
+++ b/scripts/customer-key-smoke.js
@@ -3,7 +3,16 @@
 const DEFAULT_BASE_URL = "https://www.decide.fyi";
 const DEFAULT_QUESTION = "Should this support workflow use one deterministic API verdict for routing?";
 const DEFAULT_TIMEOUT_MS = 15000;
-const VALID_DECISIONS = new Set(["yes", "no", "tie"]);
+const VALID_DECISIONS = new Set(["yes", "no"]);
+const REQUIRED_DECISION_RECORD_FIELDS = [
+  "decision_record_version",
+  "decision_id",
+  "request_id",
+  "policy_version",
+  "source_hash",
+  "record_hash",
+  "verify_url",
+];
 
 function usage() {
   console.log(`Usage:
@@ -85,6 +94,7 @@ async function postJson(url, { key, question, timeoutMs }) {
       body: JSON.stringify({
         mode: "single",
         question,
+        response_view: "full",
       }),
       signal: controller.signal,
     });
@@ -141,21 +151,29 @@ async function main() {
     throw new Error(`unexpected HTTP ${response.status}: ${JSON.stringify(json).slice(0, 300)}`);
   }
 
-  const decision = String(json.c || "").trim().toLowerCase();
+  const decision = String(json.verdict || json.c || "").trim().toLowerCase();
   if (!VALID_DECISIONS.has(decision)) {
-    throw new Error(`transport worked, but decision contract was not customer-ready: c=${JSON.stringify(json.c)} v=${JSON.stringify(json.v)}`);
+    throw new Error(`transport worked, but decision contract was not customer-ready: verdict=${JSON.stringify(json.verdict)} c=${JSON.stringify(json.c)} v=${JSON.stringify(json.v)}`);
   }
-  if (!json.request_id || !json.policy_version || !json.source_hash) {
-    throw new Error("decision response is missing request_id, policy_version, or source_hash");
+  const missingFields = REQUIRED_DECISION_RECORD_FIELDS.filter((field) => !json[field]);
+  if (json.decision_record_version !== "decision_record_v1") {
+    missingFields.push("decision_record_version=decision_record_v1");
+  }
+  if (missingFields.length) {
+    throw new Error(`decision response is missing public Decision Record fields: ${missingFields.join(", ")}`);
   }
 
   console.log("PASS customer key smoke");
   console.log(`endpoint=${endpoint}`);
   console.log(`status=${response.status}`);
   console.log(`decision=${decision}`);
+  console.log(`decision_record_version=${json.decision_record_version}`);
+  console.log(`decision_id=${json.decision_id}`);
   console.log(`request_id=${json.request_id}`);
   console.log(`policy_version=${json.policy_version}`);
   console.log(`source_hash=${json.source_hash}`);
+  console.log(`record_hash=${json.record_hash}`);
+  console.log(`verify_url=${json.verify_url}`);
   console.log(`latency_ms=${latencyMs}`);
 }
 

--- a/scripts/generate-project-inventory.sh
+++ b/scripts/generate-project-inventory.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+if ! command -v rg >/dev/null 2>&1; then
+  echo "Missing required inventory tool: ripgrep (rg)" >&2
+  exit 2
+fi
+
 REPO_NAME="$(basename "$ROOT_DIR")"
 STOCKHOLM_TS="$(TZ=Europe/Stockholm date '+%Y-%m-%d %H:%M:%S %Z')"
 ISO_TS="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"

--- a/scripts/site-bridge-regression.js
+++ b/scripts/site-bridge-regression.js
@@ -20,6 +20,9 @@ function pass(message) {
 
 const html = read("public/index.html");
 const server = JSON.parse(read("server.json"));
+const readme = read("README.md");
+const customerRunbook = read("docs/FIRST_CUSTOMER_RUNBOOK.md");
+const customerSmoke = read("scripts/customer-key-smoke.js");
 
 assert(html.includes("decide.fyi is the Decision API engine"), "home page should position Decide as API engine");
 assert(html.includes("Reference applications show the same contract powering policy MCPs"), "home page should show proof applications");
@@ -49,3 +52,18 @@ pass("MCP remotes remain stable in page and server.json");
 assert(!html.includes("Deterministic decision infrastructure: REST endpoints for systems, plus MCP notaries for agents."), "old mixed product positioning should be removed");
 assert(!server.description.includes("Krafthaus"), "server metadata should stay Decide-only");
 pass("old mixed product positioning is absent");
+
+for (const source of [
+  ["README", readme],
+  ["customer runbook", customerRunbook],
+  ["customer key smoke", customerSmoke],
+]) {
+  assert(!source[1].includes("yes`, `no`, or `tie"), `${source[0]} should not document tie as a single-decision class`);
+  assert(!source[1].includes("yes | no | tie"), `${source[0]} should not document tie as a single-decision class`);
+  assert(!source[1].includes('"yes", "no", "tie"'), `${source[0]} should not accept tie as a single-decision class`);
+}
+for (const marker of ["decision_record_version", "decision_id", "record_hash", "verify_url"]) {
+  assert(customerRunbook.includes(marker), `customer runbook should mention public Decision Record field ${marker}`);
+  assert(customerSmoke.includes(marker), `customer key smoke should validate public Decision Record field ${marker}`);
+}
+pass("customer key smoke matches public Decision Record contract");


### PR DESCRIPTION
## Summary
- update customer-key smoke to request and validate the public full Decision Record shape
- refresh first-customer runbook fields for decision_id, record_hash, verify_url, and lineage
- guard README/runbook/smoke surfaces against stale single-decision tie language

## Checks
- npm run test:site-bridge
- npm run test:contract
- DECIDE_SMOKE_API_KEY='test_customer_key_redacted' npm run smoke:customer-key -- --dry-run