### PR TITLE
Add durable Gemini usage guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,14 @@
 # deterministic Policy Notaries continue to work normally.
 DECIDE_GEMINI_MODE=disabled
 
-# Nonzero-cost opt-in only. Set all three only after explicitly approving paid
-# Gemini usage and provisioning a dedicated restricted server-side key.
+# Nonzero-cost opt-in only. Set these only after explicitly approving paid
+# Gemini usage and provisioning a dedicated restricted server-side key plus a
+# dedicated Redis-compatible REST store for the atomic usage guard.
 # DECIDE_GEMINI_MODE=paid
 # GEMINI_API_KEY=your_restricted_paid_gemini_api_key
 # DECIDE_GEMINI_MODEL=gemini-2.5-flash-lite
+# DECIDE_GEMINI_BUDGET_KV_REST_API_URL=https://your-dedicated-budget-store
+# DECIDE_GEMINI_BUDGET_KV_REST_API_TOKEN=your_dedicated_budget_store_token
 
 # Optional local/preview direct credential. Production /api/decide is protected even when omitted.
 # Clients can send either Authorization: Bearer <token> or X-API-Key: <token>
@@ -25,10 +28,13 @@ WORKFLOW_API_AUTH_REQUIRED=0
 # CI/local fixture only. Never set this in deployed environments.
 WORKFLOW_TEST_MODE=0
 
-# Optional paid-mode bounds. The runtime makes one attempt and never falls back
-# to another model.
-DECIDE_GEMINI_TIMEOUT_MS=15000
-DECIDE_GEMINI_MAX_PROMPT_CHARS=12000
+# Optional paid-mode bounds. Values may only lower the compiled ceilings. The
+# runtime makes one attempt and never falls back to another model.
+DECIDE_GEMINI_DAILY_CALL_CAP=10
+DECIDE_GEMINI_MONTHLY_CALL_CAP=100
+DECIDE_GEMINI_LIFETIME_CALL_CAP=500
+DECIDE_GEMINI_TIMEOUT_MS=8000
+DECIDE_GEMINI_MAX_PROMPT_CHARS=4096
 
 # Optional: operator-only smoke for verifying a newly provisioned customer key
 DECIDE_SMOKE_API_KEY=set_customer_key_only_when_running_smoke

--- a/.github/workflows/contract-policy-tests.yml
+++ b/.github/workflows/contract-policy-tests.yml
@@ -50,7 +50,10 @@ jobs:
           node-version: "24"
 
       - name: Run decision contract tests
-        run: npm run test:contract
+        run: |
+          npm run test:gemini-budget
+          npm run test:gemini-routing
+          npm run test:contract
 
       - name: Verify public SDK package
         run: npm run test:sdk-package

--- a/README.md
+++ b/README.md
@@ -557,12 +557,14 @@ If you run `decide` behind the `decidesite` proxy with dynamic customer keys, al
 - `DECIDE_API_KEY`: optional direct backend credential for trusted server-side callers.
 - `DECIDE_GEMINI_MODE`: defaults to `disabled`. In this hard-zero state, legacy advisory `single`, `multi`, and `runtime` requests return `DECIDE_AI_DISABLED_ZERO_COST` without reading an API key or making a provider request. Rulebook v1 remains available and never uses Gemini.
 - `DECIDE_GEMINI_MODE=paid`: explicit nonzero-cost opt-in for advisory modes. This mode also requires a restricted server-side `GEMINI_API_KEY`. `DECIDE_GEMINI_MODEL` may only be `gemini-2.5-flash-lite`; changing models requires a reviewed code release rather than an environment-only switch.
-- `DECIDE_GEMINI_TIMEOUT_MS`: the single paid-mode provider deadline (defaults to 15 seconds).
-- `DECIDE_GEMINI_MAX_PROMPT_CHARS`: the pre-fetch advisory prompt cap (defaults to 12,000; bounded to 256-20,000).
+- `DECIDE_GEMINI_BUDGET_KV_REST_API_URL` and `DECIDE_GEMINI_BUDGET_KV_REST_API_TOKEN`: dedicated Redis-compatible REST store for the atomic provider-attempt guard. Paid advisory fails closed before Gemini if this store is absent or unavailable. The legacy `DECIDE_KV_REST_API_*`/`KV_REST_API_*` names are compatibility fallbacks; dedicated credentials are preferred.
+- Compiled provider-attempt ceilings are 10/day, 100/month, 500 lifetime, and one concurrent request. `DECIDE_GEMINI_DAILY_CALL_CAP`, `DECIDE_GEMINI_MONTHLY_CALL_CAP`, and `DECIDE_GEMINI_LIFETIME_CALL_CAP` may only lower those ceilings.
+- `DECIDE_GEMINI_TIMEOUT_MS`: the single paid-mode provider deadline (defaults to and cannot exceed 8 seconds).
+- `DECIDE_GEMINI_MAX_PROMPT_CHARS`: the pre-fetch advisory prompt cap (defaults to and cannot exceed 4,096 characters; it may be lowered to 256).
 
-Paid mode makes exactly one provider attempt and never falls back to another model. Product request quotas and provider billing controls are not a zero-dollar guarantee; keep `DECIDE_GEMINI_MODE=disabled` when zero cost is required.
+Paid mode makes exactly one provider attempt and never falls back to another model. Candidate count is fixed at one, Gemini 2.5 Flash-Lite thinking is disabled, and output is capped at 8 tokens for `single`, 128 for `multi`, and 512 for `runtime`. Keep the Gemini Google Cloud project unlinked from billing for a provider-side zero-dollar boundary; the application counters limit calls but do not prove a currency amount.
 
-Rate limit: 100 requests/minute per IP.
+General `/api/decide` rate limit: 20 requests/minute per IP per serverless instance. This is an abuse control, not the Gemini cost boundary; the durable provider-attempt guard applies even when a trusted proxy bypasses the general limiter.
 
 For first-customer handoff and keyed production verification, see [`docs/FIRST_CUSTOMER_RUNBOOK.md`](docs/FIRST_CUSTOMER_RUNBOOK.md).
 

--- a/api/decide.js
+++ b/api/decide.js
@@ -13,6 +13,8 @@ import { buildRulebookAttestation } from "../lib/rulebook-attestation.js";
 import { isRulebookAttestationSignatureRequired } from "../lib/rulebook-attestation-signing.js";
 import { executeTrustedAdapter } from "../lib/trusted-adapters.js";
 import { resolveGeminiRuntimePolicy } from "../lib/gemini-model-routing.js";
+import { releaseGeminiUsage, reserveGeminiUsage } from "../lib/gemini-usage-budget.js";
+import { resolveGeminiRequestPolicy } from "../lib/gemini-request-policy.js";
 import { timingSafeEqual } from "node:crypto";
 
 // Rate limiter: 20 requests per minute per IP
@@ -281,27 +283,18 @@ function findCallerSuppliedRulebookOutputFields(body = {}) {
   );
 }
 
-function boundedTimeoutMs(value, fallback, min = 10, max = 30000) {
-  const parsed = Number.parseInt(String(value || ""), 10);
-  if (!Number.isFinite(parsed)) return fallback;
-  return Math.min(Math.max(parsed, min), max);
-}
-
 async function requestGeminiGenerateContent({
   apiKey,
   prompt,
   generationConfig,
   request_id,
   model,
+  advisoryMode,
 }) {
   const attempts = [];
   const promptText = String(prompt || "");
-  const maxPromptChars = boundedTimeoutMs(
-    process.env.DECIDE_GEMINI_MAX_PROMPT_CHARS,
-    12000,
-    256,
-    20000
-  );
+  const requestPolicy = resolveGeminiRequestPolicy({ mode: advisoryMode });
+  const maxPromptChars = requestPolicy.maxPromptChars;
   if (promptText.length > maxPromptChars) {
     return {
       ok: false,
@@ -313,7 +306,21 @@ async function requestGeminiGenerateContent({
     };
   }
 
-  const totalTimeoutMs = boundedTimeoutMs(process.env.DECIDE_GEMINI_TIMEOUT_MS, 15000);
+  const usageReservation = await reserveGeminiUsage({ requestId: request_id });
+  if (!usageReservation.allowed) {
+    const storeUnavailable = usageReservation.reason === "budget_store_unavailable";
+    return {
+      ok: false,
+      status: storeUnavailable ? 503 : 429,
+      data: null,
+      attempts,
+      errorCode: storeUnavailable ? "GEMINI_BUDGET_UNAVAILABLE" : "GEMINI_BUDGET_EXHAUSTED",
+      budgetReason: usageReservation.reason,
+      budgetUsage: usageReservation.usage,
+    };
+  }
+
+  const totalTimeoutMs = requestPolicy.timeoutMs;
   const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
   const controller = new AbortController();
   let requestTimedOut = false;
@@ -332,7 +339,12 @@ async function requestGeminiGenerateContent({
       },
       body: JSON.stringify({
         contents: [{ parts: [{ text: promptText }] }],
-        generationConfig,
+        generationConfig: {
+          ...generationConfig,
+          candidateCount: requestPolicy.candidateCount,
+          maxOutputTokens: requestPolicy.maxOutputTokens,
+          thinkingConfig: { thinkingBudget: requestPolicy.thinkingBudget },
+        },
       }),
       signal: controller.signal,
     });
@@ -393,6 +405,16 @@ async function requestGeminiGenerateContent({
     };
   } finally {
     clearTimeout(timer);
+    const released = await releaseGeminiUsage(usageReservation);
+    if (!released) {
+      console.error(
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          request_id,
+          error: "GEMINI_BUDGET_CONCURRENCY_RELEASE_FAILED",
+        })
+      );
+    }
   }
 }
 
@@ -407,6 +429,39 @@ function sendGeminiRequestFailure(res, result, request_id, lineageInput) {
         request_id,
         error: "DECIDE_AI_PROMPT_TOO_LARGE",
         message: `AI advisory prompt exceeds the ${result.maxPromptChars}-character limit.`,
+      },
+      lineageInput
+    );
+    return;
+  }
+
+  if (result?.errorCode === "GEMINI_BUDGET_UNAVAILABLE") {
+    sendDecisionJson(
+      res,
+      503,
+      {
+        c: "unclear",
+        v: "unavailable",
+        request_id,
+        error: "DECIDE_AI_BUDGET_UNAVAILABLE",
+        message: "AI advisory is paused because its durable usage guard is unavailable.",
+      },
+      lineageInput
+    );
+    return;
+  }
+
+  if (result?.errorCode === "GEMINI_BUDGET_EXHAUSTED") {
+    sendDecisionJson(
+      res,
+      429,
+      {
+        c: "unclear",
+        v: "rate_limited",
+        request_id,
+        error: "DECIDE_AI_BUDGET_EXHAUSTED",
+        message: "AI advisory has reached its pre-profit usage allowance.",
+        budget_reason: result.budgetReason,
       },
       lineageInput
     );
@@ -936,9 +991,10 @@ Rules:
       const runtimeResult = await requestGeminiGenerateContent({
         apiKey: geminiProvider.apiKey,
         prompt,
-        generationConfig: { temperature: 0.2, maxOutputTokens: 900 },
+        generationConfig: { temperature: 0.2 },
         request_id,
         model: geminiProvider.model,
+        advisoryMode: "runtime",
       });
       const data = runtimeResult.data;
       if (!runtimeResult.ok) {
@@ -1091,9 +1147,10 @@ Rules:
       const multiResult = await requestGeminiGenerateContent({
         apiKey: geminiProvider.apiKey,
         prompt,
-        generationConfig: { temperature: 0, maxOutputTokens: 220 },
+        generationConfig: { temperature: 0 },
         request_id,
         model: geminiProvider.model,
+        advisoryMode: "multi",
       });
       const data = multiResult.data;
       if (!multiResult.ok) {
@@ -1198,9 +1255,10 @@ Output exactly one of: yes, no`;
     const singleResult = await requestGeminiGenerateContent({
       apiKey: geminiProvider.apiKey,
       prompt,
-      generationConfig: { temperature: 0.7, maxOutputTokens: 10 },
+      generationConfig: { temperature: 0.7 },
       request_id,
       model: geminiProvider.model,
+      advisoryMode: "single",
     });
     const data = singleResult.data;
     if (!singleResult.ok) {

--- a/lib/gemini-request-policy.js
+++ b/lib/gemini-request-policy.js
@@ -1,0 +1,40 @@
+export const GEMINI_REQUEST_HARD_CAPS = Object.freeze({
+  promptChars: 4096,
+  timeoutMs: 8000,
+  outputTokens: Object.freeze({
+    single: 8,
+    multi: 128,
+    runtime: 512,
+  }),
+  candidateCount: 1,
+  thinkingBudget: 0,
+});
+
+function lowerOnlyInteger(value, fallback, min, hardMax) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(parsed, min), hardMax);
+}
+
+export function resolveGeminiRequestPolicy({ mode = "single", env = process.env } = {}) {
+  const safeMode = Object.prototype.hasOwnProperty.call(GEMINI_REQUEST_HARD_CAPS.outputTokens, mode)
+    ? mode
+    : "single";
+  return {
+    maxPromptChars: lowerOnlyInteger(
+      env.DECIDE_GEMINI_MAX_PROMPT_CHARS,
+      GEMINI_REQUEST_HARD_CAPS.promptChars,
+      256,
+      GEMINI_REQUEST_HARD_CAPS.promptChars
+    ),
+    timeoutMs: lowerOnlyInteger(
+      env.DECIDE_GEMINI_TIMEOUT_MS,
+      GEMINI_REQUEST_HARD_CAPS.timeoutMs,
+      10,
+      GEMINI_REQUEST_HARD_CAPS.timeoutMs
+    ),
+    maxOutputTokens: GEMINI_REQUEST_HARD_CAPS.outputTokens[safeMode],
+    candidateCount: GEMINI_REQUEST_HARD_CAPS.candidateCount,
+    thinkingBudget: GEMINI_REQUEST_HARD_CAPS.thinkingBudget,
+  };
+}

--- a/lib/gemini-usage-budget.js
+++ b/lib/gemini-usage-budget.js
@@ -1,0 +1,218 @@
+import { randomUUID } from "node:crypto";
+
+export const GEMINI_USAGE_HARD_CAPS = Object.freeze({
+  daily: 10,
+  monthly: 100,
+  lifetime: 500,
+  concurrency: 1,
+});
+
+const BUDGET_PREFIX = "decide:gemini:budget:v1";
+const STORE_TIMEOUT_MS = 1000;
+const CONCURRENCY_TTL_SECONDS = 30;
+
+const RESERVE_SCRIPT = `
+local daily = tonumber(redis.call("GET", KEYS[1]) or "0")
+local monthly = tonumber(redis.call("GET", KEYS[2]) or "0")
+local lifetime = tonumber(redis.call("GET", KEYS[3]) or "0")
+
+if daily >= tonumber(ARGV[1]) then
+  return {0, "daily", daily, monthly, lifetime}
+end
+if monthly >= tonumber(ARGV[2]) then
+  return {0, "monthly", daily, monthly, lifetime}
+end
+if lifetime >= tonumber(ARGV[3]) then
+  return {0, "lifetime", daily, monthly, lifetime}
+end
+if redis.call("EXISTS", KEYS[4]) == 1 then
+  return {0, "concurrency", daily, monthly, lifetime}
+end
+
+local locked = redis.call("SET", KEYS[4], ARGV[8], "EX", ARGV[7], "NX")
+if not locked then
+  return {0, "concurrency", daily, monthly, lifetime}
+end
+
+daily = redis.call("INCR", KEYS[1])
+monthly = redis.call("INCR", KEYS[2])
+lifetime = redis.call("INCR", KEYS[3])
+redis.call("EXPIRE", KEYS[1], ARGV[5])
+redis.call("EXPIRE", KEYS[2], ARGV[6])
+
+return {1, "allowed", daily, monthly, lifetime}
+`;
+
+const RELEASE_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`;
+
+function asLowerOnlyCap(value, hardCap) {
+  if (value === undefined || value === null || String(value).trim() === "") return hardCap;
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed)) return hardCap;
+  return Math.min(Math.max(parsed, 0), hardCap);
+}
+
+function periodKeys(now) {
+  const date = new Date(now);
+  const year = date.getUTCFullYear();
+  const monthIndex = date.getUTCMonth();
+  const day = date.getUTCDate();
+  const dayKey = `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  const monthKey = `${year}-${String(monthIndex + 1).padStart(2, "0")}`;
+  const nextDay = Date.UTC(year, monthIndex, day + 1);
+  const nextMonth = Date.UTC(year, monthIndex + 1, 1);
+  return {
+    dayKey,
+    monthKey,
+    dayTtlSeconds: Math.max(Math.ceil((nextDay - now) / 1000) + 60, 60),
+    monthTtlSeconds: Math.max(Math.ceil((nextMonth - now) / 1000) + 60, 60),
+  };
+}
+
+function normalizeStoreUrl(value) {
+  return String(value || "").trim().replace(/\/+$/, "");
+}
+
+export function resolveGeminiUsageBudgetConfig({ env = process.env, now = Date.now() } = {}) {
+  const dedicatedUrl = normalizeStoreUrl(env.DECIDE_GEMINI_BUDGET_KV_REST_API_URL);
+  const dedicatedToken = String(env.DECIDE_GEMINI_BUDGET_KV_REST_API_TOKEN || "").trim();
+  const dedicatedConfigured = Boolean(dedicatedUrl || dedicatedToken);
+  const url = dedicatedConfigured
+    ? dedicatedUrl
+    : normalizeStoreUrl(env.DECIDE_KV_REST_API_URL || env.KV_REST_API_URL);
+  const token = dedicatedConfigured
+    ? dedicatedToken
+    : String(env.DECIDE_KV_REST_API_TOKEN || env.KV_REST_API_TOKEN || "").trim();
+  const period = periodKeys(now);
+  return {
+    url,
+    token,
+    configured: Boolean(url && token),
+    dailyCap: asLowerOnlyCap(env.DECIDE_GEMINI_DAILY_CALL_CAP, GEMINI_USAGE_HARD_CAPS.daily),
+    monthlyCap: asLowerOnlyCap(env.DECIDE_GEMINI_MONTHLY_CALL_CAP, GEMINI_USAGE_HARD_CAPS.monthly),
+    lifetimeCap: asLowerOnlyCap(env.DECIDE_GEMINI_LIFETIME_CALL_CAP, GEMINI_USAGE_HARD_CAPS.lifetime),
+    concurrencyCap: GEMINI_USAGE_HARD_CAPS.concurrency,
+    dayTtlSeconds: period.dayTtlSeconds,
+    monthTtlSeconds: period.monthTtlSeconds,
+    concurrencyTtlSeconds: CONCURRENCY_TTL_SECONDS,
+    keys: {
+      daily: `${BUDGET_PREFIX}:day:${period.dayKey}`,
+      monthly: `${BUDGET_PREFIX}:month:${period.monthKey}`,
+      lifetime: `${BUDGET_PREFIX}:lifetime`,
+      concurrency: `${BUDGET_PREFIX}:concurrency`,
+    },
+  };
+}
+
+async function runEval({ config, script, keys, args, fetchImpl = globalThis.fetch }) {
+  if (!config?.configured || typeof fetchImpl !== "function") return null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), STORE_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`${config.url}/pipeline`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify([["EVAL", script, keys.length, ...keys, ...args]]),
+      signal: controller.signal,
+    });
+    if (!response?.ok) return null;
+    const payload = await response.json().catch(() => null);
+    const first = Array.isArray(payload) ? payload[0] : null;
+    if (!first || first.error) return null;
+    return first.result;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function usageFromResult(result) {
+  return {
+    daily: Number(result?.[2] || 0),
+    monthly: Number(result?.[3] || 0),
+    lifetime: Number(result?.[4] || 0),
+  };
+}
+
+function denialReason(value) {
+  if (value === "daily") return "daily_cap_reached";
+  if (value === "monthly") return "monthly_cap_reached";
+  if (value === "lifetime") return "lifetime_cap_reached";
+  if (value === "concurrency") return "concurrency_cap_reached";
+  return "budget_store_unavailable";
+}
+
+export async function reserveGeminiUsage({
+  env = process.env,
+  now = Date.now(),
+  requestId = "",
+  reservationId = "",
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const config = resolveGeminiUsageBudgetConfig({ env, now });
+  if (!config.configured) {
+    return { allowed: false, reason: "budget_store_unavailable", usage: null };
+  }
+
+  const token = String(reservationId || `${requestId || "request"}:${randomUUID()}`);
+  const result = await runEval({
+    config,
+    script: RESERVE_SCRIPT,
+    keys: [config.keys.daily, config.keys.monthly, config.keys.lifetime, config.keys.concurrency],
+    args: [
+      config.dailyCap,
+      config.monthlyCap,
+      config.lifetimeCap,
+      config.concurrencyCap,
+      config.dayTtlSeconds,
+      config.monthTtlSeconds,
+      config.concurrencyTtlSeconds,
+      token,
+    ],
+    fetchImpl,
+  });
+
+  if (!Array.isArray(result) || result.length < 5) {
+    return { allowed: false, reason: "budget_store_unavailable", usage: null };
+  }
+
+  const usage = usageFromResult(result);
+  if (Number(result[0]) !== 1) {
+    return { allowed: false, reason: denialReason(String(result[1] || "")), usage };
+  }
+
+  return {
+    allowed: true,
+    reason: "allowed",
+    reservationId: token,
+    lockKey: config.keys.concurrency,
+    usage,
+  };
+}
+
+export async function releaseGeminiUsage(reservation, {
+  env = process.env,
+  now = Date.now(),
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (!reservation?.allowed || !reservation.reservationId || !reservation.lockKey) return false;
+  const config = resolveGeminiUsageBudgetConfig({ env, now });
+  if (!config.configured) return false;
+  const result = await runEval({
+    config,
+    script: RELEASE_SCRIPT,
+    keys: [reservation.lockKey],
+    args: [reservation.reservationId],
+    fetchImpl,
+  });
+  return Number(result) === 1;
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "report:mcp-adoption": "node scripts/report-mcp-adoption.js",
     "workflow:test": "NODE_ENV=test WORKFLOW_TEST_MODE=1 node scripts/workflow-zendesk-refund-test.js",
     "test:gemini-routing": "node scripts/test-gemini-model-routing.js",
+    "test:gemini-budget": "node scripts/test-gemini-usage-budget.js",
     "test:request-query": "node scripts/request-query-regression.test.js",
     "test:release-gates": "node scripts/test-release-gates.js",
     "test:site-bridge": "node scripts/site-bridge-regression.js",

--- a/scripts/test-decision-contract.js
+++ b/scripts/test-decision-contract.js
@@ -33,6 +33,30 @@ import { invokeJson } from "./test-helpers/http-harness.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = join(__dirname, "fixtures", "decision-contract");
+const CONTRACT_GEMINI_BUDGET_URL = "https://gemini-budget.contract.test";
+process.env.DECIDE_GEMINI_BUDGET_KV_REST_API_URL = CONTRACT_GEMINI_BUDGET_URL;
+process.env.DECIDE_GEMINI_BUDGET_KV_REST_API_TOKEN = "contract-budget-token";
+
+function createBudgetedGeminiFetch(providerFetch) {
+  return async (url, options = {}) => {
+    if (String(url).startsWith(`${CONTRACT_GEMINI_BUDGET_URL}/`)) {
+      const pipeline = JSON.parse(String(options.body || "[]"));
+      const command = pipeline?.[0] || [];
+      const keyCount = Number(command[2]);
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          if (command[0] !== "EVAL") return [{ error: "unexpected budget command" }];
+          if (keyCount === 4) return [{ result: [1, "allowed", 1, 1, 1] }];
+          if (keyCount === 1) return [{ result: 1 }];
+          return [{ error: "unexpected budget key count" }];
+        },
+      };
+    }
+    return providerFetch(url, options);
+  };
+}
 
 function loadFixture(fileName) {
   return JSON.parse(readFileSync(join(FIXTURE_DIR, fileName), "utf8"));
@@ -260,7 +284,7 @@ async function testDecideSingleFixture() {
   process.env.GEMINI_API_KEY = "contract-test";
   process.env.DECIDE_API_KEY = "";
   process.env.DECIDE_GEMINI_MODE = "paid";
-  global.fetch = async () => ({
+  global.fetch = createBudgetedGeminiFetch(async () => ({
     ok: true,
     async json() {
       return {
@@ -273,10 +297,13 @@ async function testDecideSingleFixture() {
         ],
       };
     },
-  });
+  }));
 
   try {
-    const result = await invokeJson(decideHandler, fixture.request);
+    const result = await invokeJson(decideHandler, {
+      ...fixture.request,
+      headers: { ...(fixture.request.headers || {}), "x-forwarded-for": "127.0.0.201" },
+    });
     assert.equal(result.statusCode, fixture.expect.statusCode, "decide status mismatch");
     assert.equal(result.json?.c, fixture.expect.c, "decide c mismatch");
     assert.equal(result.json?.v, fixture.expect.v, "decide v mismatch");
@@ -313,7 +340,7 @@ async function testDecideMultiAdvisoryContract() {
   process.env.GEMINI_API_KEY = "contract-test";
   process.env.DECIDE_API_KEY = "";
   process.env.DECIDE_GEMINI_MODE = "paid";
-  global.fetch = async () => ({
+  global.fetch = createBudgetedGeminiFetch(async () => ({
     ok: true,
     async json() {
       return {
@@ -326,7 +353,7 @@ async function testDecideMultiAdvisoryContract() {
         ],
       };
     },
-  });
+  }));
 
   try {
     const result = await invokeJson(decideHandler, request);
@@ -354,7 +381,7 @@ async function testDecideApiKeyFixture() {
   process.env.GEMINI_API_KEY = "contract-test";
   process.env.DECIDE_API_KEY = "decide-auth-token";
   process.env.DECIDE_GEMINI_MODE = "paid";
-  global.fetch = async () => ({
+  global.fetch = createBudgetedGeminiFetch(async () => ({
     ok: true,
     async json() {
       return {
@@ -367,7 +394,7 @@ async function testDecideApiKeyFixture() {
         ],
       };
     },
-  });
+  }));
 
   try {
     const unauthorized = await invokeJson(decideHandler, fixture.request);
@@ -411,14 +438,14 @@ async function testDecideProductionRequiresTrustedEdge() {
   process.env.DECIDE_GEMINI_MODE = "paid";
   delete process.env.DECIDE_API_AUTH_REQUIRED;
   process.env.VERCEL_ENV = "production";
-  global.fetch = async () => ({
+  global.fetch = createBudgetedGeminiFetch(async () => ({
     ok: true,
     async json() {
       return {
         candidates: [{ content: { parts: [{ text: "yes" }] } }],
       };
     },
-  });
+  }));
 
   try {
     const direct = await invokeJson(decideHandler, fixture.request);
@@ -456,7 +483,7 @@ async function testDecideRuntimeFixture() {
   process.env.GEMINI_API_KEY = "contract-test";
   process.env.DECIDE_API_KEY = "";
   process.env.DECIDE_GEMINI_MODE = "paid";
-  global.fetch = async () => ({
+  global.fetch = createBudgetedGeminiFetch(async () => ({
     ok: true,
     async json() {
       return {
@@ -486,10 +513,13 @@ async function testDecideRuntimeFixture() {
         ],
       };
     },
-  });
+  }));
 
   try {
-    const result = await invokeJson(decideHandler, fixture.request);
+    const result = await invokeJson(decideHandler, {
+      ...fixture.request,
+      headers: { ...(fixture.request.headers || {}), "x-forwarded-for": "127.0.0.202" },
+    });
     assert.equal(result.statusCode, fixture.expect.statusCode, "decide runtime status mismatch");
     assert.equal(result.json?.status, "ok", "decide runtime status field mismatch");
     assert.equal(result.json?.engine, "decide", "decide runtime engine mismatch");
@@ -3043,6 +3073,113 @@ async function testDecideGeminiPaidMissingKeyFailsClosed() {
   }
 }
 
+async function testDecideGeminiBudgetMissingFailsClosed() {
+  const fixture = loadFixture("decide-single.json");
+  const originalFetch = global.fetch;
+  const envKeys = [
+    "GEMINI_API_KEY",
+    "DECIDE_API_KEY",
+    "DECIDE_GEMINI_MODE",
+    "DECIDE_GEMINI_MODEL",
+    "DECIDE_GEMINI_BUDGET_KV_REST_API_URL",
+    "DECIDE_GEMINI_BUDGET_KV_REST_API_TOKEN",
+    "DECIDE_KV_REST_API_URL",
+    "DECIDE_KV_REST_API_TOKEN",
+    "KV_REST_API_URL",
+    "KV_REST_API_TOKEN",
+  ];
+  const previousEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+  process.env.GEMINI_API_KEY = "contract-test";
+  process.env.DECIDE_API_KEY = "";
+  process.env.DECIDE_GEMINI_MODE = "paid";
+  process.env.DECIDE_GEMINI_MODEL = "gemini-2.5-flash-lite";
+  for (const key of envKeys.slice(4)) delete process.env[key];
+  let providerCalls = 0;
+  global.fetch = async () => {
+    providerCalls += 1;
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return { candidates: [{ content: { parts: [{ text: "yes" }] } }] };
+      },
+    };
+  };
+
+  try {
+    const result = await invokeJson(decideHandler, {
+      ...fixture.request,
+      headers: { ...(fixture.request.headers || {}), "x-forwarded-for": "127.0.0.211" },
+    });
+    assert.equal(result.statusCode, 503, "paid advisory must fail closed without its durable budget store");
+    assert.equal(result.json?.error, "DECIDE_AI_BUDGET_UNAVAILABLE", "missing budget store error mismatch");
+    assert.equal(providerCalls, 0, "missing budget store must prevent every provider call");
+  } finally {
+    global.fetch = originalFetch;
+    for (const key of envKeys) {
+      if (previousEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = previousEnv[key];
+    }
+  }
+}
+
+async function testDecideGeminiBudgetCapFailsClosed() {
+  const fixture = loadFixture("decide-single.json");
+  const originalFetch = global.fetch;
+  const envKeys = [
+    "GEMINI_API_KEY",
+    "DECIDE_API_KEY",
+    "DECIDE_GEMINI_MODE",
+    "DECIDE_GEMINI_MODEL",
+    "DECIDE_GEMINI_BUDGET_KV_REST_API_URL",
+    "DECIDE_GEMINI_BUDGET_KV_REST_API_TOKEN",
+  ];
+  const previousEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+  process.env.GEMINI_API_KEY = "contract-test";
+  process.env.DECIDE_API_KEY = "";
+  process.env.DECIDE_GEMINI_MODE = "paid";
+  process.env.DECIDE_GEMINI_MODEL = "gemini-2.5-flash-lite";
+  process.env.DECIDE_GEMINI_BUDGET_KV_REST_API_URL = "https://budget.example.test";
+  process.env.DECIDE_GEMINI_BUDGET_KV_REST_API_TOKEN = "budget-test-token";
+  let providerCalls = 0;
+  global.fetch = createBudgetedGeminiFetch(async (url) => {
+    if (String(url).startsWith("https://budget.example.test/")) {
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return [{ result: [0, "monthly", 4, 100, 221] }];
+        },
+      };
+    }
+    providerCalls += 1;
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return { candidates: [{ content: { parts: [{ text: "yes" }] } }] };
+      },
+    };
+  });
+
+  try {
+    const result = await invokeJson(decideHandler, {
+      ...fixture.request,
+      headers: { ...(fixture.request.headers || {}), "x-forwarded-for": "127.0.0.212" },
+    });
+    assert.equal(result.statusCode, 429, "exhausted durable advisory budget must reject the request");
+    assert.equal(result.json?.error, "DECIDE_AI_BUDGET_EXHAUSTED", "budget cap error mismatch");
+    assert.equal(result.json?.budget_reason, "monthly_cap_reached", "budget cap reason mismatch");
+    assert.equal(providerCalls, 0, "exhausted durable budget must prevent every provider call");
+  } finally {
+    global.fetch = originalFetch;
+    for (const key of envKeys) {
+      if (previousEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = previousEnv[key];
+    }
+  }
+}
+
 async function testDecideGeminiPaidSingleAttempt() {
   const fixture = loadFixture("decide-single.json");
   const originalFetch = global.fetch;
@@ -3060,8 +3197,10 @@ async function testDecideGeminiPaidSingleAttempt() {
   process.env.DECIDE_GEMINI_MODEL = "gemini-2.5-flash-lite";
   process.env.DECIDE_GEMINI_LOW_LATENCY_MODEL_LADDER = "gemini-3.1-pro-preview,gemini-3.5-flash";
   const urls = [];
-  global.fetch = async (url) => {
+  const providerBodies = [];
+  global.fetch = createBudgetedGeminiFetch(async (url, options = {}) => {
     urls.push(String(url));
+    providerBodies.push(JSON.parse(String(options.body || "{}")));
     return {
       ok: false,
       status: 503,
@@ -3069,17 +3208,31 @@ async function testDecideGeminiPaidSingleAttempt() {
         return { error: { message: "temporarily unavailable" } };
       },
     };
-  };
+  });
 
   try {
-    const result = await invokeJson(decideHandler, fixture.request);
-    assert.equal(result.statusCode, 200, "paid provider failure should preserve advisory response compatibility");
+    const result = await invokeJson(decideHandler, {
+      ...fixture.request,
+      headers: { ...(fixture.request.headers || {}), "x-forwarded-for": "127.0.0.214" },
+    });
+    assert.equal(
+      result.statusCode,
+      200,
+      `paid provider failure should preserve advisory response compatibility: ${JSON.stringify(result.json)}`
+    );
     assert.equal(result.json?.c, "unclear", "paid provider failure must fail closed");
     assert.equal(urls.length, 1, "paid mode must make exactly one provider attempt");
     assert.match(
       urls[0],
       /models\/gemini-2\.5-flash-lite:generateContent/,
       "paid mode must use the exact reviewed model"
+    );
+    assert.equal(providerBodies[0]?.generationConfig?.candidateCount, 1, "paid mode must request one candidate");
+    assert.equal(providerBodies[0]?.generationConfig?.maxOutputTokens, 8, "single mode output cap mismatch");
+    assert.equal(
+      providerBodies[0]?.generationConfig?.thinkingConfig?.thinkingBudget,
+      0,
+      "Flash-Lite thinking must remain disabled"
     );
   } finally {
     global.fetch = originalFetch;
@@ -3100,7 +3253,7 @@ async function testDecideGeminiEmptyTextSingleAttempt() {
   process.env.DECIDE_GEMINI_MODE = "paid";
   process.env.DECIDE_GEMINI_MODEL = "gemini-2.5-flash-lite";
   let fetchCalls = 0;
-  global.fetch = async () => {
+  global.fetch = createBudgetedGeminiFetch(async () => {
     fetchCalls += 1;
     return {
       ok: true,
@@ -3109,7 +3262,7 @@ async function testDecideGeminiEmptyTextSingleAttempt() {
         return { candidates: [{ content: { parts: [{ text: "" }] } }] };
       },
     };
-  };
+  });
 
   try {
     const result = await invokeJson(decideHandler, fixture.request);
@@ -3143,7 +3296,7 @@ async function testDecideGeminiDeadline() {
   process.env.DECIDE_GEMINI_MODE = "paid";
   process.env.DECIDE_GEMINI_MODEL = "gemini-2.5-flash-lite";
   process.env.DECIDE_GEMINI_TIMEOUT_MS = "20";
-  global.fetch = async (_url, options = {}) =>
+  global.fetch = createBudgetedGeminiFetch(async (_url, options = {}) =>
     new Promise((_resolve, reject) => {
       signalSeen = Boolean(options.signal);
       const fallback = setTimeout(() => reject(new Error("Gemini wait exceeded without abort")), 100);
@@ -3158,7 +3311,7 @@ async function testDecideGeminiDeadline() {
         },
         { once: true }
       );
-    });
+    }));
 
   try {
     const startedAt = Date.now();
@@ -4469,6 +4622,8 @@ async function main() {
     ["decide-gemini-disabled-preserves-deterministic-guards", testDecideGeminiDisabledPreservesDeterministicGuards],
     ["decide-gemini-disabled-runtime-lineage", testDecideGeminiDisabledRuntimeLineage],
     ["decide-gemini-paid-missing-key-fails-closed", testDecideGeminiPaidMissingKeyFailsClosed],
+    ["decide-gemini-budget-missing-fails-closed", testDecideGeminiBudgetMissingFailsClosed],
+    ["decide-gemini-budget-cap-fails-closed", testDecideGeminiBudgetCapFailsClosed],
     ["decide-gemini-paid-single-attempt", testDecideGeminiPaidSingleAttempt],
     ["decide-gemini-empty-text-single-attempt", testDecideGeminiEmptyTextSingleAttempt],
     ["decide-gemini-deadline", testDecideGeminiDeadline],

--- a/scripts/test-gemini-usage-budget.js
+++ b/scripts/test-gemini-usage-budget.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import {
+  GEMINI_USAGE_HARD_CAPS,
+  releaseGeminiUsage,
+  reserveGeminiUsage,
+  resolveGeminiUsageBudgetConfig,
+} from "../lib/gemini-usage-budget.js";
+import {
+  GEMINI_REQUEST_HARD_CAPS,
+  resolveGeminiRequestPolicy,
+} from "../lib/gemini-request-policy.js";
+
+const BUDGET_ENV = {
+  DECIDE_GEMINI_BUDGET_KV_REST_API_URL: "https://budget.example.test",
+  DECIDE_GEMINI_BUDGET_KV_REST_API_TOKEN: "test-token",
+};
+
+assert.deepEqual(GEMINI_USAGE_HARD_CAPS, {
+  daily: 10,
+  monthly: 100,
+  lifetime: 500,
+  concurrency: 1,
+});
+assert.deepEqual(GEMINI_REQUEST_HARD_CAPS, {
+  promptChars: 4096,
+  timeoutMs: 8000,
+  outputTokens: { single: 8, multi: 128, runtime: 512 },
+  candidateCount: 1,
+  thinkingBudget: 0,
+});
+
+assert.deepEqual(resolveGeminiRequestPolicy({ mode: "single", env: {} }), {
+  maxPromptChars: 4096,
+  timeoutMs: 8000,
+  maxOutputTokens: 8,
+  candidateCount: 1,
+  thinkingBudget: 0,
+});
+assert.deepEqual(
+  resolveGeminiRequestPolicy({
+    mode: "runtime",
+    env: {
+      DECIDE_GEMINI_MAX_PROMPT_CHARS: "999999",
+      DECIDE_GEMINI_TIMEOUT_MS: "999999",
+    },
+  }),
+  {
+    maxPromptChars: 4096,
+    timeoutMs: 8000,
+    maxOutputTokens: 512,
+    candidateCount: 1,
+    thinkingBudget: 0,
+  }
+);
+assert.deepEqual(
+  resolveGeminiRequestPolicy({
+    mode: "multi",
+    env: {
+      DECIDE_GEMINI_MAX_PROMPT_CHARS: "1000",
+      DECIDE_GEMINI_TIMEOUT_MS: "2500",
+    },
+  }),
+  {
+    maxPromptChars: 1000,
+    timeoutMs: 2500,
+    maxOutputTokens: 128,
+    candidateCount: 1,
+    thinkingBudget: 0,
+  }
+);
+
+const defaults = resolveGeminiUsageBudgetConfig({
+  env: BUDGET_ENV,
+  now: Date.UTC(2026, 7, 13, 10, 0, 0),
+});
+assert.equal(defaults.configured, true);
+assert.equal(defaults.dailyCap, 10);
+assert.equal(defaults.monthlyCap, 100);
+assert.equal(defaults.lifetimeCap, 500);
+assert.equal(defaults.concurrencyCap, 1);
+assert.match(defaults.keys.daily, /2026-08-13$/);
+assert.match(defaults.keys.monthly, /2026-08$/);
+
+const lowered = resolveGeminiUsageBudgetConfig({
+  env: {
+    ...BUDGET_ENV,
+    DECIDE_GEMINI_DAILY_CALL_CAP: "4",
+    DECIDE_GEMINI_MONTHLY_CALL_CAP: "40",
+    DECIDE_GEMINI_LIFETIME_CALL_CAP: "200",
+  },
+});
+assert.equal(lowered.dailyCap, 4);
+assert.equal(lowered.monthlyCap, 40);
+assert.equal(lowered.lifetimeCap, 200);
+
+const attemptedRaise = resolveGeminiUsageBudgetConfig({
+  env: {
+    ...BUDGET_ENV,
+    DECIDE_GEMINI_DAILY_CALL_CAP: "999",
+    DECIDE_GEMINI_MONTHLY_CALL_CAP: "999",
+    DECIDE_GEMINI_LIFETIME_CALL_CAP: "999",
+  },
+});
+assert.equal(attemptedRaise.dailyCap, GEMINI_USAGE_HARD_CAPS.daily);
+assert.equal(attemptedRaise.monthlyCap, GEMINI_USAGE_HARD_CAPS.monthly);
+assert.equal(attemptedRaise.lifetimeCap, GEMINI_USAGE_HARD_CAPS.lifetime);
+
+const incompleteDedicatedStore = resolveGeminiUsageBudgetConfig({
+  env: {
+    DECIDE_GEMINI_BUDGET_KV_REST_API_URL: "https://dedicated.example.test",
+    DECIDE_KV_REST_API_URL: "https://shared.example.test",
+    DECIDE_KV_REST_API_TOKEN: "shared-token-must-not-be-mixed",
+  },
+});
+assert.equal(incompleteDedicatedStore.configured, false);
+assert.equal(incompleteDedicatedStore.url, "https://dedicated.example.test");
+assert.equal(incompleteDedicatedStore.token, "");
+
+let fetchCalls = 0;
+const missingStore = await reserveGeminiUsage({
+  env: {},
+  fetchImpl: async () => {
+    fetchCalls += 1;
+    throw new Error("missing configuration must fail before fetch");
+  },
+});
+assert.equal(missingStore.allowed, false);
+assert.equal(missingStore.reason, "budget_store_unavailable");
+assert.equal(fetchCalls, 0);
+
+const commands = [];
+const allowed = await reserveGeminiUsage({
+  env: BUDGET_ENV,
+  requestId: "req_budget_allowed",
+  reservationId: "reservation-test-token",
+  fetchImpl: async (url, options) => {
+    commands.push({ url: String(url), options });
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return [{ result: [1, "allowed", 1, 1, 1] }];
+      },
+    };
+  },
+});
+assert.equal(allowed.allowed, true);
+assert.equal(allowed.reservationId, "reservation-test-token");
+assert.deepEqual(allowed.usage, { daily: 1, monthly: 1, lifetime: 1 });
+assert.equal(commands.length, 1);
+assert.match(commands[0].url, /\/pipeline$/);
+const reservationPipeline = JSON.parse(commands[0].options.body);
+assert.equal(reservationPipeline[0][0], "EVAL");
+assert.equal(reservationPipeline[0][2], 4);
+
+const denied = await reserveGeminiUsage({
+  env: BUDGET_ENV,
+  fetchImpl: async () => ({
+    ok: true,
+    status: 200,
+    async json() {
+      return [{ result: [0, "daily", 10, 33, 88] }];
+    },
+  }),
+});
+assert.equal(denied.allowed, false);
+assert.equal(denied.reason, "daily_cap_reached");
+assert.deepEqual(denied.usage, { daily: 10, monthly: 33, lifetime: 88 });
+
+let releaseCommand = null;
+const released = await releaseGeminiUsage(allowed, {
+  env: BUDGET_ENV,
+  fetchImpl: async (_url, options) => {
+    releaseCommand = JSON.parse(options.body);
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return [{ result: 1 }];
+      },
+    };
+  },
+});
+assert.equal(released, true);
+assert.equal(releaseCommand[0][0], "EVAL");
+
+console.log("PASS Gemini durable usage budget");


### PR DESCRIPTION
## Summary
- enforce atomic daily, monthly, lifetime, and concurrency limits before Gemini
- pin the low-cost model and reduce prompt, output, and timeout ceilings
- fail closed when the durable budget store is unavailable

## Verification
- npm run test:gemini-budget
- npm run test:gemini-routing
- npm run test:contract
- npm run test:release-gates

Production remains zero-cost until a dedicated budget store and Gemini key are provisioned.